### PR TITLE
Update regular expression for downloading Little Snitch

### DIFF
--- a/Little Snitch/Little Snitch.download.recipe
+++ b/Little Snitch/Little Snitch.download.recipe
@@ -30,7 +30,7 @@
                         <string>Safari 8.0.2</string>
                     </dict>
                     <key>re_pattern</key>
-                    <string>(LittleSnitch-*\d.\d.\d.dmg)</string>
+                    <string>(LittleSnitch-[\d\.]+\.dmg)</string>
                 </dict>
             </dict>
             <dict>

--- a/Little Snitch/Little Snitch.download.recipe
+++ b/Little Snitch/Little Snitch.download.recipe
@@ -44,6 +44,10 @@
                     <string>https://www.obdev.at/downloads/littlesnitch/%match%</string>
                 </dict>
             </dict>
+            <dict>
+                <key>Processor</key>
+                <string>EndOfCheckPhase</string>
+            </dict>
         </array>
     </dict>
 </plist>

--- a/Little Snitch/Little Snitch.install.recipe
+++ b/Little Snitch/Little Snitch.install.recipe
@@ -19,10 +19,6 @@
         <array>
             <dict>
                 <key>Processor</key>
-                <string>EndOfCheckPhase</string>
-            </dict>
-            <dict>
-                <key>Processor</key>
                 <string>Installer</string>
             </dict>
         </array>


### PR DESCRIPTION
According to Little Snitch's developer, 4.4 patches a major vulnerability:
https://www.obdev.at/products/littlesnitch/releasenotes.html

This pull request updates your download recipe to work with typical version schemes, including two-segment versions like `4.4`.