### PR TITLE
Update ZoomIT.download.recipe

### DIFF
--- a/Zoom/ZoomIT.download.recipe
+++ b/Zoom/ZoomIT.download.recipe
@@ -67,7 +67,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>input_plist_path</key>
-                    <string>%RECIPE_CACHE_DIR%/unpack/Contents/Info.plist</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack/zoom.us.app/Contents/Info.plist</string>
                     <key>plist_version_key</key>
                     <string>CFBundleShortVersionString</string>
                 </dict>


### PR DESCRIPTION
PR is for this issue:

[https://github.com/autopkg/smithjw-recipes/issues/7](https://github.com/autopkg/smithjw-recipes/issues/7)

Changes line 70 from:

`<string>%RECIPE_CACHE_DIR%/unpack/Contents/Info.plist</string>`

To:

`<string>%RECIPE_CACHE_DIR%/unpack/zoom.us.app/Contents/Info.plist</string>`