### PR TITLE
RubyMine.pkg.recipe - Switched back to Copier from FileMover

### DIFF
--- a/RubyMine/RubyMine.pkg.recipe
+++ b/RubyMine/RubyMine.pkg.recipe
@@ -42,12 +42,12 @@
 			</dict>
 			<dict>
 				<key>Processor</key>
-				<string>FileMover</string>
+				<string>Copier</string>
 				<key>Arguments</key>
 				<dict>
-					<key>source</key>
+					<key>source_path</key>
 					<string>%pathname%/RubyMine.app</string>
-					<key>target</key>
+					<key>destination_path</key>
 					<string>%pkgroot%/Applications/RubyMine.app</string>
 				</dict>
 			</dict>


### PR DESCRIPTION
Continuously got the following error using the FileMover processor:

`[Errno 20] Not a directory: '/Users/raymondlyon/Library/AutoPkg/Cache/local.jss.RubyMine-riskified/downloads/RubyMine-2020.2.3.dmg/RubyMine.app' -> '/Users/raymondlyon/Library/AutoPkg/Cache/local.jss.RubyMine-riskified/RubyMine/Applications/RubyMine.app'
Failed.`

Switched to Copier and it worked without issue. 
