### PR TITLE
Key 'supported_architectures' should be an array and not only a string

### DIFF
--- a/Docker/Docker.munki.recipe.yaml
+++ b/Docker/Docker.munki.recipe.yaml
@@ -11,10 +11,11 @@ Input:
       - testing
     description: Spice up your Dock a little.
     developer: Docker Inc
-    display_name: Docker
-    name: '%NAME%-%ARCHITECTURE%'
+    display_name: '%NAME'
+    name: '%NAME%'
     unattended_install: true
-    supported_architectures: '%ARCHITECTURE%'
+    supported_architectures:
+    - '%ARCHITECTURE%'
 
 Process:
   - Processor: MunkiImporter

--- a/Docker/Docker.munki.recipe.yaml
+++ b/Docker/Docker.munki.recipe.yaml
@@ -15,7 +15,7 @@ Input:
     name: '%NAME%'
     unattended_install: true
     supported_architectures:
-    - '%ARCHITECTURE%'
+      - '%ARCHITECTURE%'
 
 Process:
   - Processor: MunkiImporter


### PR DESCRIPTION
To work properly with munkiadmin according to @hjuutilainen:

https://macadmins.slack.com/archives/C0D7FU2Q1/p1647623269525709
https://macadmins.slack.com/archives/C0D7FU2Q1/p1647632972333489

Plus a cleanup of the name variable according to @gregneagle Munki will handle the different architectures