### PR TITLE
Make supported architectures array, not string

### DIFF
--- a/Docker/Docker.munki.recipe.yaml
+++ b/Docker/Docker.munki.recipe.yaml
@@ -15,7 +15,8 @@ Input:
     display_name: Docker
     name: '%NAME%-%ARCHITECTURE%'
     unattended_install: true
-    supported_architectures: '%ARCHITECTURE%'
+    supported_architectures:
+      - '%ARCHITECTURE%'
 
 Process:
   - Processor: MunkiImporter


### PR DESCRIPTION
From https://github.com/munki/munki/wiki/Supported-Pkginfo-Keys
> supported_architectures
> array of strings

Even if it's only one string, I believe it should be an array with a single string in the array, rather than a string outside of an array.