### PR TITLE
Added arch to cache path to prevent race conditions with concurrent runs

### DIFF
--- a/Docker/Docker.pkg.recipe.yaml
+++ b/Docker/Docker.pkg.recipe.yaml
@@ -12,7 +12,7 @@ Process:
     Arguments:
       pkgdirs:
         Applications: '0775'
-      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgroot: '%RECIPE_CACHE_DIR%-%ARCHITECTURE%/payload'
 
   - Processor: Copier
     Arguments:
@@ -28,7 +28,7 @@ Process:
             user: root
         id: '%bundleid%'
         options: purge_ds_store
-        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgdir: '%RECIPE_CACHE_DIR%-%ARCHITECTURE%'
         pkgname: '%NAME%-%ARCHITECTURE%-%version%'
         scripts: scripts
 
@@ -36,4 +36,4 @@ Process:
     Arguments:
       fail_deleter_silently: true
       path_list:
-        - '%RECIPE_CACHE_DIR%/payload'
+        - '%RECIPE_CACHE_DIR%-%ARCHITECTURE%/payload'


### PR DESCRIPTION
This PR adds the architecture being built for to the cache path. I was running into an issue running AutoPkg recipes with concurrency where the x86 and arm64 builds for Docker would read/write from/to the same cache path, resulting in some weird behaviour. This fix would mean that those recipe runs are granted different folders for assembling the pkg.