### PR TITLE
Adjust parent for VSCode jamf recipe

### DIFF
--- a/Microsoft/Visual_Studio_Code.jamf.recipe.yaml
+++ b/Microsoft/Visual_Studio_Code.jamf.recipe.yaml
@@ -1,5 +1,5 @@
 Identifier: com.github.smithjw.jamf.Visual_Studio_Code
-ParentRecipe: com.github.killahquam.pkg.visualstudioscode
+ParentRecipe: com.github.amsysuk-recipes.pkg.VisualStudioCode
 MinimumVersion: '2.3'
 
 Input:

--- a/Slack/Slack.jamf.recipe.yaml
+++ b/Slack/Slack.jamf.recipe.yaml
@@ -1,6 +1,6 @@
 Description: Downloads the latest version and makes a pkg. Then, uploads the package to the Jamf Pro Server and creates a Self Service Policy and Smart Group.
 Identifier: com.github.smithjw.jamf.Slack
-ParentRecipe: com.github.killahquam.pkg.slack
+ParentRecipe: com.github.rtrouton.pkg.SlackUniversal
 MinimumVersion: '2.3'
 
 Input:


### PR DESCRIPTION
The recipes in killahquam-recipes have been deprecated and will be removed soon. (See https://github.com/autopkg/killahquam-recipes/issues/28 for details.)

This pull request adjusts the parent for a recipe that references killahquam-recipes. The parent has been changed to an actively maintained recipe in another repo.