### PR TITLE
Moved re_pattern to Input and adjusted for 1.11

### DIFF
--- a/DisplayLink/DisplayLink_Manager.download.recipe.yaml
+++ b/DisplayLink/DisplayLink_Manager.download.recipe.yaml
@@ -7,17 +7,19 @@ Input:
   SOFTWARE_TITLE: DisplayLink_Manager
   BASE_URL: https://www.synaptics.com
   SEARCH_URL: products/displaylink-graphics/downloads/macos
+  RE_PATTERN_1: /products/displaylink-.+\?filetype=exe
+  RE_PATTERN_2: <a.*href="(?P<download_url>.*[.]pkg)" download>Accept<\/a>
   LOGIN_EXTENSION_URL: https://www.synaptics.com/sites/default/files/exe_files/2021-02/macOS%20App%20LoginExtension-EXE.dmg
 
 Process:
   - Processor: URLTextSearcher
     Arguments:
-      re_pattern: /%SEARCH_URL%.+\?filetype=exe
+      re_pattern: '%RE_PATTERN_1%'
       url: '%BASE_URL%/%SEARCH_URL%'
 
   - Processor: URLTextSearcher
     Arguments:
-      re_pattern: <a.*href="(?P<download_url>.*[.]pkg)" download>Accept<\/a>
+      re_pattern: '%RE_PATTERN_2%'
       url: '%BASE_URL%%match%'
 
   - Processor: URLDownloader


### PR DESCRIPTION
Potential fix for #53. I have moved the two regex patterns into the Input to make future adjustments easier for users downstream, especially since the vendor doesn't appear to be consistent with their download file path scheme. I have also reduced the default pattern so that it works with 1.11, but would also still match if the vendor reverted to a previous path scheme.