### PR TITLE
Adjust Kap recipes to use wardsparadox-recipes Kap.download as parent recipe

### DIFF
--- a/Kap/Kap.download.recipe.yaml
+++ b/Kap/Kap.download.recipe.yaml
@@ -8,6 +8,10 @@ Input:
   DOWNLOAD_ARCHITECTURE: x64
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: Consider switching to the Kap recipes in the wardsparadox-recipes repo. This recipe is deprecated and will be removed in the future.
+
   - Processor: GitHubReleasesInfoProvider
     Arguments:
       github_repo: 'wulkano/kap'

--- a/Kap/Kap.jamf.recipe.yaml
+++ b/Kap/Kap.jamf.recipe.yaml
@@ -7,13 +7,13 @@ Input:
   NAME: Kap
   SOFTWARE_TITLE: '%NAME%'
   CATEGORY: Utilities
-  ARCHITECTURE: 'x86_64'
-  GROUP_CRITERIA: '%ARCHITECTURE%'
-  GROUP_NAME: 'Architecture - %ARCHITECTURE%'
+  ARCHITECTURE: '%ARCH%'
+  GROUP_CRITERIA: '%ARCH%'
+  GROUP_NAME: 'Architecture - %ARCH%'
   GROUP_TEMPLATE: 'SmartGroup-architecture-smart.xml'
   POLICY_CATEGORY: Testing
   POLICY_TEMPLATE: PolicyTemplate.xml
-  POLICY_NAME: 'Install Latest %NAME% (%ARCHITECTURE%)'
+  POLICY_NAME: 'Install Latest %NAME% (%ARCH%)'
   POLICY_RUN_COMMAND: ' '
   SELF_SERVICE_DISPLAY_NAME: 'Install Latest %NAME%'
   SELF_SERVICE_DESCRIPTION: An open-source screen recorder built with web technology

--- a/Kap/Kap.pkg.recipe.yaml
+++ b/Kap/Kap.pkg.recipe.yaml
@@ -1,6 +1,6 @@
 Description: Downloads the latest version of Kap and creates a package.
 Identifier: com.github.smithjw.pkg.Kap
-ParentRecipe: com.github.smithjw.download.Kap
+ParentRecipe: com.github.autopkg.wardsparadox.download.Kap
 MinimumVersion: '2.3'
 
 Input:
@@ -9,4 +9,4 @@ Input:
 Process:
   - Processor: AppPkgCreator
     Arguments:
-      pkg_path: '%RECIPE_CACHE_DIR%/%NAME%-%ARCHITECTURE%-%version%.pkg'
+      pkg_path: '%RECIPE_CACHE_DIR%/%NAME%-%ARCH%-%version%.pkg'

--- a/Kap/Kap.sign.recipe.yaml
+++ b/Kap/Kap.sign.recipe.yaml
@@ -15,4 +15,4 @@ Process:
     Arguments:
       fail_deleter_silently: True
       path_list:
-        - '%RECIPE_CACHE_DIR%/%NAME%-%ARCHITECTURE%-%version%-unsigned.pkg'
+        - '%RECIPE_CACHE_DIR%/%NAME%-%ARCH%-%version%-unsigned.pkg'


### PR DESCRIPTION
In order to minimize redundancy across the AutoPkg org, this PR deprecates the Kap.download recipe in favor of the one in wardsparadox-recipes. The other Kap recipes in this repo have been adjusted to use the new parent, along with ARCH input values (note that expected values are `x86_64` or `arm64`, and will be adjusted for GitHub asset matching automatically).