### PR TITLE
Deprecate ZoomMeetings recipe

### DIFF
--- a/Zoom/ZoomMeetings.download.recipe
+++ b/Zoom/ZoomMeetings.download.recipe
@@ -16,9 +16,18 @@
             <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.3.1</string>
+        <string>1.1</string>
         <key>Process</key>
         <array>
+            <dict>
+                <key>Processor</key>
+                <string>DeprecationWarning</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>warning_message</key>
+                    <string>Consider switching to the Zoom_IT recipes in this repo. This recipe is deprecated and will be removed in the future.</string>
+                </dict>
+            </dict>
             <dict>
                 <key>Processor</key>
                 <string>URLDownloader</string>


### PR DESCRIPTION
This PR deprecates the non-functional Zoom Meetings recipes, and points users to the Zoom_IT recipes elsewhere in this repo.
