### PR TITLE
Fix Android Studio CodeSignatureVerifier key name

### DIFF
--- a/Android Studio/Android_Studio.download.recipe.yaml
+++ b/Android Studio/Android_Studio.download.recipe.yaml
@@ -27,5 +27,5 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
-      requirements: 'identifier "com.google.android.studio" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV'
+      requirement: 'identifier "com.google.android.studio" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV'
       input_path: '%pathname%/Android Studio.app'


### PR DESCRIPTION
This PR changes the key name from `requirements` to `requirement` for Android Studio code signature verification.