### PR TITLE
Deprecate Box Drive recipes

### DIFF
--- a/Box/Box Drive.download.recipe
+++ b/Box/Box Drive.download.recipe
@@ -14,9 +14,18 @@
 			<string>Box Drive</string>
 		</dict>
 		<key>MinimumVersion</key>
-		<string>0.2.0</string>
+		<string>1.1</string>
 		<key>Process</key>
 		<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Box Drive recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 			<dict>
 				<key>Arguments</key>
 				<dict>


### PR DESCRIPTION
This PR deprecates the Box Drive recipes in this repo. These recipes don't include CodeSignatureVerifier, and are otherwise insufficiently distinct from the ones in the dataJAR-recipes repo to justify the extra maintenance. The deprecation message points users of these recipes to the dataJAR-recipes repo for alternatives.
