### PR TITLE
Update DisplayLink Manager recipes for new download and naming scheme

### DIFF
--- a/DisplayLink/DisplayLink_Manager.download.recipe.yaml
+++ b/DisplayLink/DisplayLink_Manager.download.recipe.yaml
@@ -30,9 +30,9 @@ Process:
   - Processor: Unarchiver
     Arguments:
       archive_path: '%pathname%'
-      destination_path: '%RECIPE_CACHE_DIR%/%NAME%'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
       purge_destination: true
-
+  
   - Processor: URLDownloader
     Arguments:
       filename: '%SOFTWARE_TITLE%_Extension.dmg'
@@ -50,7 +50,7 @@ Process:
         - 'Developer ID Installer: DisplayLink Corp (73YQY62QM3)'
         - Developer ID Certification Authority
         - Apple Root CA
-      input_path: '%RECIPE_CACHE_DIR%/%NAME%/DisplayLink*.pkg'
+      input_path: '%RECIPE_CACHE_DIR%/unpack/*.pkg'
 
   - Processor: CodeSignatureVerifier
     Arguments:

--- a/DisplayLink/DisplayLink_Manager.download.recipe.yaml
+++ b/DisplayLink/DisplayLink_Manager.download.recipe.yaml
@@ -8,7 +8,7 @@ Input:
   BASE_URL: https://www.synaptics.com
   SEARCH_URL: products/displaylink-graphics/downloads/macos
   RE_PATTERN_1: /products/displaylink-.+\?filetype=exe
-  RE_PATTERN_2: <a.*href="(?P<download_url>.*[.]pkg)" download>Accept<\/a>
+  RE_PATTERN_2: <a.*href="(?P<download_url>.*[.]zip)" download>Accept<\/a>
   LOGIN_EXTENSION_URL: https://www.synaptics.com/sites/default/files/exe_files/2021-02/macOS%20App%20LoginExtension-EXE.dmg
 
 Process:
@@ -24,8 +24,14 @@ Process:
 
   - Processor: URLDownloader
     Arguments:
-      filename: '%SOFTWARE_TITLE%.pkg'
+      filename: '%SOFTWARE_TITLE%.zip'
       url: '%BASE_URL%%download_url%'
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%pathname%'
+      destination_path: '%RECIPE_CACHE_DIR%/%NAME%'
+      purge_destination: true
 
   - Processor: URLDownloader
     Arguments:
@@ -44,7 +50,7 @@ Process:
         - 'Developer ID Installer: DisplayLink Corp (73YQY62QM3)'
         - Developer ID Certification Authority
         - Apple Root CA
-      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.pkg'
+      input_path: '%RECIPE_CACHE_DIR%/%NAME%/DisplayLink*.pkg'
 
   - Processor: CodeSignatureVerifier
     Arguments:

--- a/DisplayLink/DisplayLink_Manager.pkg.recipe.yaml
+++ b/DisplayLink/DisplayLink_Manager.pkg.recipe.yaml
@@ -15,9 +15,13 @@ Process:
         pkgroot: '0775'
         Scripts: '0775'
 
+  - Processor: FileFinder
+    Arguments:
+      pattern: '%RECIPE_CACHE_DIR%/unpack/*.pkg'
+
   - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
     Arguments:
-      archive_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.pkg'
+      archive_path: '%found_filename%'
       file_to_extract: Distribution
 
   - Processor: com.github.mlbz521.SharedProcessors/XPathParser
@@ -36,8 +40,12 @@ Process:
 
   - Processor: PkgCopier
     Arguments:
-      source_pkg: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.pkg'
+      source_pkg: '%found_filename%'
       pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%/Scripts/%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: FileFinder
+    Arguments:
+      pattern: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%_Extension.dmg/*.pkg'
 
   - Processor: PkgCopier
     Arguments:


### PR DESCRIPTION
Synaptics has changed a few things around with the DisplayLink package. Found the recipe failing today during a scheduled run. This works for me, but please test and let me know if any changes needed. 

- Update the regex pattern to properly match and download a .zip archive.
- Unarchive and update the code signature path.
- Move around `FileFinder` and additional processors as necessary to handle the base and extension packages.