### PR TITLE
Update download URLs for Docker Desktop

### DIFF
--- a/Docker/Docker-Universal.download.recipe.yaml
+++ b/Docker/Docker-Universal.download.recipe.yaml
@@ -9,31 +9,21 @@ MinimumVersion: '2.3'
 
 Input:
   NAME: Docker
+  arm_dl_url: "https://desktop.docker.com/mac/main/arm64/Docker.dmg"
+  intel_dl_url: "https://desktop.docker.com/mac/main/amd64/Docker.dmg"
 
 Process:
-  - Processor: URLTextSearcher
-    Arguments:
-      re_pattern: '((\w+):\/\/(\S*)(arm64)(\S*)(dmg)(?=\?))'
-      result_output_var_name: match
-      url: 'https://www.docker.com/get-started'
-
   - Processor: com.github.jgstew.SharedProcessors/URLDownloaderPython
     Arguments:
       filename: 'Docker-arm64.dmg'
       download_dir: '%RECIPE_CACHE_DIR%/downloads'
-      url: '%match%'
-
-  - Processor: URLTextSearcher
-    Arguments:
-      re_pattern: '((\w+):\/\/(\S*)(amd64)(\S*)(dmg)(?=\?))'
-      result_output_var_name: match
-      url: 'https://www.docker.com/get-started'
+      url: '%arm_dl_url%'
 
   - Processor: com.github.jgstew.SharedProcessors/URLDownloaderPython
     Arguments:
       filename: 'Docker-x86_64.dmg'
       download_dir: '%RECIPE_CACHE_DIR%/downloads'
-      url: '%match%'
+      url: '%intel_dl_url%'
 
   - Processor: EndOfCheckPhase
   - Processor: com.github.jgstew.SharedProcessors/StopProcessingIfDownloadUnchanged

--- a/Docker/Docker.download.recipe.yaml
+++ b/Docker/Docker.download.recipe.yaml
@@ -15,17 +15,11 @@ Input:
   DOWNLOAD_TYPE: amd64
 
 Process:
-  - Processor: URLTextSearcher
-    Arguments:
-      re_pattern: ((\w+):\/\/(\S*)(%DOWNLOAD_TYPE%)(\S*)(dmg)(?=\?))
-      result_output_var_name: match
-      url: https://www.docker.com/get-started
-
   - Processor: com.github.jgstew.SharedProcessors/URLDownloaderPython
     Arguments:
       filename: 'Docker-%ARCHITECTURE%.dmg'
       download_dir: '%RECIPE_CACHE_DIR%/downloads'
-      url: '%match%'
+      url: 'https://desktop.docker.com/mac/main/%DOWNLOAD_TYPE%/Docker.dmg'
 
   - Processor: EndOfCheckPhase
   - Processor: com.github.jgstew.SharedProcessors/StopProcessingIfDownloadUnchanged


### PR DESCRIPTION
On or about 7/23/25, Docker changed the contents of the "get-started" page that these recipes scraped to find the download URLs for Docker Desktop DMGs, thus breaking the recipes. 

This change switches from trying to regex match content on that page to instead use URLs from the download buttons on the main page, with the specific architecture build type in the path as a variable for the non-universal. These have worked well for me thus far. 

This addresses https://github.com/autopkg/smithjw-recipes/issues/72