### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/DisplayLink/DisplayLink_Manager.pkg.recipe.yaml
+++ b/DisplayLink/DisplayLink_Manager.pkg.recipe.yaml
@@ -89,7 +89,6 @@ Process:
       pkg_request:
         id: 'com.displaylink.displaylinkmanagerapp'
         version: '%version%'
-        options: purge_ds_store
         pkgname: '%SOFTWARE_TITLE%-%version%'
         pkgdir: '%RECIPE_CACHE_DIR%'
         pkgroot: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%/pkgroot'

--- a/Docker/Docker-Universal.pkg.recipe.yaml
+++ b/Docker/Docker-Universal.pkg.recipe.yaml
@@ -92,7 +92,6 @@ Process:
     Arguments:
       pkg_request:
         id: '%bundleid%'
-        options: purge_ds_store
         pkgdir: '%RECIPE_CACHE_DIR%'
         pkgname: '%NAME%_Universal-%version%'
         pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'

--- a/Docker/Docker.pkg.recipe.yaml
+++ b/Docker/Docker.pkg.recipe.yaml
@@ -83,7 +83,6 @@ Process:
     Arguments:
       pkg_request:
         id: '%bundleid%'
-        options: purge_ds_store
         pkgdir: '%RECIPE_CACHE_DIR%'
         pkgname: '%NAME%-%ARCHITECTURE%-%version%'
         pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'

--- a/Figma/Figma-Universal.pkg.recipe.yaml
+++ b/Figma/Figma-Universal.pkg.recipe.yaml
@@ -50,7 +50,6 @@ Process:
       pkg_request:
         id: '%bundleid%'
         version: '%version%'
-        options: purge_ds_store
         pkgname: '%NAME%-Universal-%version%'
         pkgdir: '%RECIPE_CACHE_DIR%'
         scripts: '%RECIPE_CACHE_DIR%/Universal/Scripts'

--- a/GitHub/GitHub_Desktop-Universal.pkg.recipe.yaml
+++ b/GitHub/GitHub_Desktop-Universal.pkg.recipe.yaml
@@ -48,7 +48,6 @@ Process:
       pkg_request:
         id: '%bundleid%'
         version: '%version%'
-        options: purge_ds_store
         pkgname: '%SOFTWARE_TITLE%-Universal-%version%'
         pkgdir: '%RECIPE_CACHE_DIR%'
         scripts: '%RECIPE_CACHE_DIR%/Universal/Scripts'

--- a/JetBrains/RubyMine.pkg.recipe
+++ b/JetBrains/RubyMine.pkg.recipe
@@ -65,8 +65,6 @@
 						<string>%version%</string>
 						<key>id</key>
 						<string>com.rubymine</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>chown</key>
 						<array>
 							<dict>

--- a/Keka/Keka.pkg.recipe
+++ b/Keka/Keka.pkg.recipe
@@ -76,8 +76,6 @@
                     <dict>
                         <key>id</key>
                         <string>%bundleid%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>pkgname</key>
                         <string>%NAME%-%version%</string>
                         <key>pkgroot</key>

--- a/Little Snitch/Little Snitch.pkg.recipe
+++ b/Little Snitch/Little Snitch.pkg.recipe
@@ -345,8 +345,6 @@
                         </array>
                         <key>id</key>
                         <string>%bundleid%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>pkgname</key>
                         <string>%NAME%-%version%</string>
                         <key>pkgroot</key>

--- a/Luxafor/Luxafor.pkg.recipe
+++ b/Luxafor/Luxafor.pkg.recipe
@@ -67,8 +67,6 @@
                     <dict>
                         <key>id</key>
                         <string>%CFBundleIdentifier%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>pkgname</key>
                         <string>%NAME%-%CFBundleShortVersionString%</string>
                         <key>pkgroot</key>

--- a/Microsoft Remote Desktop Beta/Microsoft Remote Desktop Beta.pkg.recipe
+++ b/Microsoft Remote Desktop Beta/Microsoft Remote Desktop Beta.pkg.recipe
@@ -39,8 +39,6 @@
 						</array>
 						<key>id</key>
 						<string>%BUNDLE_ID%</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>pkgname</key>
 						<string>%NAME%-%version%</string>
 						<key>pkgroot</key>

--- a/Postman/Postman-Universal.pkg.recipe.yaml
+++ b/Postman/Postman-Universal.pkg.recipe.yaml
@@ -47,7 +47,6 @@ Process:
       pkg_request:
         id: '%bundleid%'
         version: '%version%'
-        options: purge_ds_store
         pkgname: '%NAME%-Universal-%version%'
         pkgdir: '%RECIPE_CACHE_DIR%'
         scripts: '%RECIPE_CACHE_DIR%/Universal/Scripts'

--- a/PowerShell/PowerShell-Universal.pkg.recipe.yaml
+++ b/PowerShell/PowerShell-Universal.pkg.recipe.yaml
@@ -58,7 +58,6 @@ Process:
     Arguments:
       pkg_request:
         id: '%bundleid%'
-        options: purge_ds_store
         pkgdir: '%RECIPE_CACHE_DIR%'
         pkgname: '%NAME%-Universal-%version%'
         pkgroot: '%RECIPE_CACHE_DIR%/Universal/pkgroot'

--- a/Smile/PDFPen.pkg.recipe
+++ b/Smile/PDFPen.pkg.recipe
@@ -64,8 +64,6 @@
 						<string>%version%</string>
 						<key>id</key>
 						<string>com.viscosity</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>chown</key>
 						<array>
 							<dict>

--- a/Smile/PDFPenPro.pkg.recipe
+++ b/Smile/PDFPenPro.pkg.recipe
@@ -64,8 +64,6 @@
 						<string>%version%</string>
 						<key>id</key>
 						<string>com.viscosity</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>chown</key>
 						<array>
 							<dict>

--- a/Viscosity/Viscosity.pkg.recipe
+++ b/Viscosity/Viscosity.pkg.recipe
@@ -65,8 +65,6 @@
 						<string>%version%</string>
 						<key>id</key>
 						<string>com.viscosity</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>chown</key>
 						<array>
 							<dict>

--- a/Wireshark/Wireshark.pkg.recipe.yaml
+++ b/Wireshark/Wireshark.pkg.recipe.yaml
@@ -26,7 +26,6 @@ Process:
             path: Applications
             user: root
         id: '%bundleid%'
-        options: purge_ds_store
         pkgdir: '%RECIPE_CACHE_DIR%'
         pkgname: '%NAME%-%ARCHITECTURE%-%version%'
         scripts: scripts


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._