### PR TITLE
Update source_pkg to use dmg_found_filename

### DIFF
--- a/Tenable/Nessus_Agent.pkg.recipe.yaml
+++ b/Tenable/Nessus_Agent.pkg.recipe.yaml
@@ -10,5 +10,5 @@ Input:
 Process:
 - Processor: PkgCopier
   Arguments:
-    source_pkg: '%pathname%/.NessusAgent.pkg'
+    source_pkg: '%pathname%/%dmg_found_filename%'
     pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'


### PR DESCRIPTION
Looks like Tenable have changed the pkg path in the dmg to no longer have the period prefix.  I've created a pull request to fix the parent recipe too.