### PR TITLE
DisplayLink Manager download/pkg recipe fix

### DIFF
--- a/DisplayLink/DisplayLink_Manager.download.recipe.yaml
+++ b/DisplayLink/DisplayLink_Manager.download.recipe.yaml
@@ -8,7 +8,7 @@ Input:
   BASE_URL: https://www.synaptics.com
   SEARCH_URL: products/displaylink-graphics/downloads/macos
   RE_PATTERN_1: /products/displaylink-.+\?filetype=exe
-  RE_PATTERN_2: <a.*href="(?P<download_url>.*[.]zip)" download>Accept<\/a>
+  RE_PATTERN_2: <a.*href="(?P<download_url>.*[.]pkg)" download>Accept<\/a>
   LOGIN_EXTENSION_URL: https://www.synaptics.com/sites/default/files/exe_files/2021-02/macOS%20App%20LoginExtension-EXE.dmg
 
 Process:
@@ -24,14 +24,8 @@ Process:
 
   - Processor: URLDownloader
     Arguments:
-      filename: '%SOFTWARE_TITLE%.zip'
+      filename: '%SOFTWARE_TITLE%.pkg'
       url: '%BASE_URL%%download_url%'
-
-  - Processor: Unarchiver
-    Arguments:
-      archive_path: '%pathname%'
-      destination_path: '%RECIPE_CACHE_DIR%/unpack'
-      purge_destination: true
 
   - Processor: URLDownloader
     Arguments:
@@ -50,7 +44,7 @@ Process:
         - 'Developer ID Installer: DisplayLink Corp (73YQY62QM3)'
         - Developer ID Certification Authority
         - Apple Root CA
-      input_path: '%RECIPE_CACHE_DIR%/unpack/*.pkg'
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.pkg'
 
   - Processor: CodeSignatureVerifier
     Arguments:

--- a/DisplayLink/DisplayLink_Manager.pkg.recipe.yaml
+++ b/DisplayLink/DisplayLink_Manager.pkg.recipe.yaml
@@ -15,13 +15,9 @@ Process:
         pkgroot: '0775'
         Scripts: '0775'
 
-  - Processor: FileFinder
-    Arguments:
-      pattern: '%RECIPE_CACHE_DIR%/unpack/*.pkg'
-
   - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
     Arguments:
-      archive_path: '%found_filename%'
+      archive_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.pkg'
       file_to_extract: Distribution
 
   - Processor: com.github.mlbz521.SharedProcessors/XPathParser
@@ -40,7 +36,7 @@ Process:
 
   - Processor: PkgCopier
     Arguments:
-      source_pkg: '%found_filename%'
+      source_pkg: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.pkg'
       pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%/Scripts/%SOFTWARE_TITLE%-%version%.pkg'
 
   - Processor: FileFinder


### PR DESCRIPTION
Reverts b7828ab and 5dbff9d as vendor switched back from ZIP to PKG.