### PR TITLE
Update DisplayLink to use the vendor package

### DIFF
--- a/DisplayLink/DisplayLink_Manager.download.recipe.yaml
+++ b/DisplayLink/DisplayLink_Manager.download.recipe.yaml
@@ -9,7 +9,6 @@ Input:
   SEARCH_URL: products/displaylink-graphics/downloads/macos
   RE_PATTERN_1: /products/displaylink-.+\?filetype=exe
   RE_PATTERN_2: <a.*href="(?P<download_url>.*[.]pkg)" download>Accept<\/a>
-  LOGIN_EXTENSION_URL: https://www.synaptics.com/sites/default/files/exe_files/2021-02/macOS%20App%20LoginExtension-EXE.dmg
 
 Process:
   - Processor: URLTextSearcher
@@ -27,15 +26,6 @@ Process:
       filename: '%SOFTWARE_TITLE%.pkg'
       url: '%BASE_URL%%download_url%'
 
-  - Processor: URLDownloader
-    Arguments:
-      filename: '%SOFTWARE_TITLE%_Extension.dmg'
-      url: '%LOGIN_EXTENSION_URL%'
-
-  - Processor: FileFinder
-    Arguments:
-      pattern: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%_Extension.dmg/*.pkg'
-
   - Processor: EndOfCheckPhase
 
   - Processor: CodeSignatureVerifier
@@ -45,11 +35,3 @@ Process:
         - Developer ID Certification Authority
         - Apple Root CA
       input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.pkg'
-
-  - Processor: CodeSignatureVerifier
-    Arguments:
-      expected_authority_names:
-        - 'Developer ID Installer: DisplayLink Corp (73YQY62QM3)'
-        - Developer ID Certification Authority
-        - Apple Root CA
-      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%_Extension.dmg/%found_basename%'

--- a/DisplayLink/DisplayLink_Manager.jamf.recipe.yaml
+++ b/DisplayLink/DisplayLink_Manager.jamf.recipe.yaml
@@ -1,6 +1,6 @@
 Description: Downloads the latest version of the DisplayLink Manager App, then uploads to your Jamf Pro instance.
 Identifier: com.github.smithjw.jamf.DisplayLink_Manager
-ParentRecipe: com.github.smithjw.pkg.DisplayLink_Manager
+ParentRecipe: com.github.smithjw.download.DisplayLink_Manager
 MinimumVersion: '2.3'
 
 Input:

--- a/DisplayLink/DisplayLink_Manager.pkg.recipe.yaml
+++ b/DisplayLink/DisplayLink_Manager.pkg.recipe.yaml
@@ -8,6 +8,10 @@ Input:
   SOFTWARE_TITLE: DisplayLink_Manager
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: "This recipe has been deprecated, please switch to com.github.smithjw.download.DisplayLink_Manager."
+
   - Processor: PkgRootCreator
     Arguments:
       pkgroot: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%'


### PR DESCRIPTION
As discussed on Slack, the vendor provided DisplayLink Manager package now includes the login window extension, so there is no need to download it separately and repackage then together.

This PR
- Removes that download step
- Deprecates the PKG recipe
- Points the Jamf recipe at the download as a parent

[DisplayLink_Manager.download.recipe.yaml.log](https://github.com/user-attachments/files/26151197/DisplayLink_Manager.download.recipe.yaml.log)
