### PR TITLE
feat(draw_io): ✨ Add download, packaging, and upload recipes for draw.io

### DIFF
--- a/AWS_CLI/AWS_CLI.download.recipe.yaml
+++ b/AWS_CLI/AWS_CLI.download.recipe.yaml
@@ -1,0 +1,32 @@
+Description: Downloads the latest version of the AWS Command Line Interface.
+Identifier: com.github.smithjw.download.AWS_CLI
+MinimumVersion: '2.9'
+
+Input:
+  NAME: AWS CLI
+  SOFTWARE_TITLE: AWS_CLI
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      fetch_filename: AWSCLIV2.pkg
+      url: https://awscli.amazonaws.com/AWSCLIV2.pkg
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: AMZN Mobile LLC (94KV3E626L)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/AWS_CLI/AWS_CLI.pkg.recipe.yaml
+++ b/AWS_CLI/AWS_CLI.pkg.recipe.yaml
@@ -1,0 +1,32 @@
+Description: Creates an installer package for the latest version of the AWS Command Line Interface.
+Identifier: com.github.smithjw.pkg.AWS_CLI
+ParentRecipe: com.github.smithjw.download.AWS_CLI
+MinimumVersion: '2.9'
+
+Input:
+  NAME: AWS CLI
+  SOFTWARE_TITLE: AWS_CLI
+
+Process:
+  - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
+    Arguments:
+      archive_path: '%pathname%'
+      file_to_extract: Distribution
+
+  - Processor: com.github.mlbz521.SharedProcessors/XPathParser
+    Arguments:
+      attribute_one: version
+      return_variable_attribute_one: version
+      xml_file: '%extracted_file%'
+      xpath: .//pkg-ref[@id="com.amazon.aws.cli2"][@version]
+
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/extractedfile'

--- a/AWS_CLI/AWS_CLI.upload.jamf.recipe.yaml
+++ b/AWS_CLI/AWS_CLI.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.AWS_CLI
+ParentRecipe: com.github.smithjw.pkg.AWS_CLI
+MinimumVersion: '2.9'
+
+Input:
+  NAME: AWS CLI
+  SOFTWARE_TITLE: AWS_CLI
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Amazon_Corretto/Amazon_Corretto_JDK.download.recipe.yaml
+++ b/Amazon_Corretto/Amazon_Corretto_JDK.download.recipe.yaml
@@ -1,0 +1,52 @@
+Comment: |
+  This recipe leverages Amazon's permanent links so that it can be overrided to fetch multiple versions
+  Valid options for JDK_VERSION are 8, 11, 17, 21, 23, & 24
+Description: Downloads the current release version of Amazon Corretto JDK for macOS.
+Identifier: com.github.smithjw.download.Amazon_Corretto_JDK
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Amazon Corretto JDK
+  SOFTWARE_TITLE: Amazon_Corretto_JDK
+  JDK_VERSION: '24'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-%JDK_VERSION%-arm64.pkg'
+      url: https://corretto.aws/downloads/latest/amazon-corretto-%JDK_VERSION%-aarch64-macos-jdk.pkg
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-%JDK_VERSION%-x86_64.pkg'
+      url: https://corretto.aws/downloads/latest/amazon-corretto-%JDK_VERSION%-x64-macos-jdk.pkg
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: AMZN Mobile LLC (94KV3E626L)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%JDK_VERSION%-arm64.pkg'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: AMZN Mobile LLC (94KV3E626L)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%JDK_VERSION%-x86_64.pkg'

--- a/Amazon_Corretto/Amazon_Corretto_JDK.pkg.recipe.yaml
+++ b/Amazon_Corretto/Amazon_Corretto_JDK.pkg.recipe.yaml
@@ -1,0 +1,63 @@
+Comment: |
+  This recipe leverages Amazon's permanent links so that it can be overrided to fetch multiple versions
+  Valid options for JDK_VERSION are 8, 11, 17, 21, 23, & 24
+Description: Downloads the current version of Amazon Corretto JDK and updates the package version
+Identifier: com.github.smithjw.pkg.Amazon_Corretto_JDK
+ParentRecipe: com.github.smithjw.download.Amazon_Corretto_JDK
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Amazon Corretto JDK
+  SOFTWARE_TITLE: Amazon_Corretto_JDK
+
+Process:
+  - Processor: com.github.dataJAR-recipes.Shared Processors/DistributionPkgInfo
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%JDK_VERSION%-arm64.pkg'
+
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%JDK_VERSION%-arm64.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-arm64.pkg'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%JDK_VERSION%-x86_64.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-x86_64.pkg'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/sbin/installer -pkg %SOFTWARE_TITLE%-arm64.pkg -target /
+        else
+          /usr/sbin/installer -pkg %SOFTWARE_TITLE%-x86_64.pkg -target /
+        fi
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: '%pkg_id%'
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/Amazon_Corretto/Amazon_Corretto_JDK.upload.jamf.recipe.yaml
+++ b/Amazon_Corretto/Amazon_Corretto_JDK.upload.jamf.recipe.yaml
@@ -1,0 +1,34 @@
+Comment: |
+  This recipe leverages Amazon's permanent links so that it can be overrided to fetch multiple versions
+  Valid options for JDK_VERSION are 8, 11, 17, 21, 23, & 24
+Description: Downloads the current version of Amazon Corretto JDK and updates the package version
+Identifier: com.github.smithjw.jamf.upload.Amazon_Corretto_JDK
+ParentRecipe: com.github.smithjw.pkg.Amazon_Corretto_JDK
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Amazon Corretto JDK
+  SOFTWARE_TITLE: Amazon_Corretto_JDK
+  JDK_VERSION: '17'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-%JDK_VERSION%'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Anthropic/Claude.download.recipe.yaml
+++ b/Anthropic/Claude.download.recipe.yaml
@@ -33,5 +33,7 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%pathname%/Claude.app'
       requirement: identifier "com.anthropic.claudefordesktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Q6L2SF6YDW

--- a/Anthropic/Claude_Code.download.recipe.yaml
+++ b/Anthropic/Claude_Code.download.recipe.yaml
@@ -42,6 +42,8 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%RECIPE_CACHE_DIR%/downloads/claude-arm64-%version%'
       requirement: |
         identifier "com.anthropic.claude-code" and anchor apple generic and
@@ -51,6 +53,8 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%RECIPE_CACHE_DIR%/downloads/claude-x86_64-%version%'
       requirement: |
         identifier "com.anthropic.claude-code" and anchor apple generic and

--- a/Axure/Axure_RP_10.download.recipe.yaml
+++ b/Axure/Axure_RP_10.download.recipe.yaml
@@ -1,0 +1,52 @@
+Description: Download recipe of Axure RP 10
+Identifier: com.github.smithjw.download.Axure_RP_10
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Axure RP 10
+  SOFTWARE_TITLE: Axure_RP_10
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      re_pattern: https://axure.cachefly.net/versions/10-0/AxureRP-Setup-arm64-[\d+]+\.dmg
+      url: https://www.axure.com/release-history/rp10
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-arm64.dmg'
+      url: '%match%'
+
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: https://axure.cachefly.net/versions/10-0/AxureRP-Setup-[\d+]+\.dmg
+      url: https://www.axure.com/release-history/rp10
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      filename: '%SOFTWARE_TITLE%-x86_64.dmg'
+      url: '%match%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Axure RP 10.app'
+      requirement: identifier "com.axure.AxureRP10" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HUMW6UU796
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg/Axure RP 10.app'
+      requirement: identifier "com.axure.AxureRP10" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HUMW6UU796

--- a/Axure/Axure_RP_10.pkg.recipe.yaml
+++ b/Axure/Axure_RP_10.pkg.recipe.yaml
@@ -1,0 +1,67 @@
+Description: Downloads the latest version of Axure RP 10 and creates a package.
+Identifier: com.github.smithjw.pkg.Axure_RP_10
+ParentRecipe: com.github.smithjw.download.Axure_RP_10
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Axure RP 10
+  SOFTWARE_TITLE: Axure_RP_10
+
+Process:
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-arm64.dmg'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-x86_64.dmg'
+
+  - Processor: PlistReader
+    Arguments:
+      info_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Axure RP 10.app/Contents/Info.plist'
+      plist_keys:
+        CFBundleIdentifier: bundleid
+        CFBundleName: app_name
+        CFBundleVersion: version
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/bin/hdiutil attach "Axure_RP_10-arm64.dmg" -mountpoint "/Volumes/Axure_RP_10" -nobrowse
+        else
+          /usr/bin/hdiutil attach "Axure_RP_10-x86_64.dmg" -mountpoint "/Volumes/Axure_RP_10" -nobrowse
+        fi
+
+        /bin/cp -R "/Volumes/Axure_RP_10/Axure RP 10.app" "/Applications/Axure RP 10.app"
+        /usr/bin/hdiutil detach "/Volumes/Axure_RP_10"
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: '%bundleid%'
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/Axure/Axure_RP_10.upload.jamf.recipe.yaml
+++ b/Axure/Axure_RP_10.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Axure_RP_10
+ParentRecipe: com.github.smithjw.pkg.Axure_RP_10
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Axure RP 10
+  SOFTWARE_TITLE: Axure_RP_10
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-10'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Axure/Axure_RP_11.download.recipe.yaml
+++ b/Axure/Axure_RP_11.download.recipe.yaml
@@ -1,0 +1,42 @@
+Description: Downloads the latest version of Axure RP.
+Identifier: com.github.smithjw.download.Axure_RP_11
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Axure RP 11
+  SOFTWARE_TITLE: Axure_RP_11
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-arm64.dmg'
+      url: https://axure.cachefly.net/AxureRP-Setup-arm64.dmg
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-x86_64.dmg'
+      url: https://axure.cachefly.net/AxureRP-Setup.dmg
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg/Axure RP 11.app'
+      requirement: identifier "com.axure.AxureRP11" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HUMW6UU796
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Axure RP 11.app'
+      requirement: identifier "com.axure.AxureRP11" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HUMW6UU796

--- a/Axure/Axure_RP_11.pkg.recipe.yaml
+++ b/Axure/Axure_RP_11.pkg.recipe.yaml
@@ -1,0 +1,67 @@
+Description: Downloads the latest version of Axure RP 11 and creates a package.
+Identifier: com.github.smithjw.pkg.Axure_RP_11
+ParentRecipe: com.github.smithjw.download.Axure_RP_11
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Axure RP 11
+  SOFTWARE_TITLE: Axure_RP_11
+
+Process:
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-arm64.dmg'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-x86_64.dmg'
+
+  - Processor: PlistReader
+    Arguments:
+      info_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Axure RP 11.app/Contents/Info.plist'
+      plist_keys:
+        CFBundleIdentifier: bundleid
+        CFBundleName: app_name
+        CFBundleVersion: version
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/bin/hdiutil attach "Axure_RP_11-arm64.dmg" -mountpoint "/Volumes/Axure_RP_11" -nobrowse
+        else
+          /usr/bin/hdiutil attach "Axure_RP_11-x86_64.dmg" -mountpoint "/Volumes/Axure_RP_11" -nobrowse
+        fi
+
+        /bin/cp -R "/Volumes/Axure_RP_11/Axure RP 11.app" "/Applications/Axure RP 11.app"
+        /usr/bin/hdiutil detach "/Volumes/Axure_RP_11"
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: '%bundleid%'
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/Axure/Axure_RP_11.upload.jamf.recipe.yaml
+++ b/Axure/Axure_RP_11.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Axure_RP_11
+ParentRecipe: com.github.smithjw.pkg.Axure_RP_11
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Axure RP 11
+  SOFTWARE_TITLE: Axure_RP_11
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-11'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Axure/Axure_RP_9.download.recipe.yaml
+++ b/Axure/Axure_RP_9.download.recipe.yaml
@@ -1,0 +1,39 @@
+Description: Download recipe of Axure RP 9
+Identifier: com.github.smithjw.download.Axure_RP_9
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Axure RP 9
+  SOFTWARE_TITLE: Axure_RP_9
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      re_pattern: https://axure.cachefly.net/versions/9-0/AxureRP-Setup-[\d+]+\.dmg
+      url: https://www.axure.com/release-history/rp9
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.dmg'
+      url: '%match%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/Axure RP 9.app'
+      requirement: |
+        identifier "com.axure.AxureRP9" and anchor apple generic and
+        certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and
+        certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and
+        certificate leaf[subject.OU] = HUMW6UU796

--- a/Axure/Axure_RP_9.pkg.recipe.yaml
+++ b/Axure/Axure_RP_9.pkg.recipe.yaml
@@ -1,0 +1,22 @@
+Description: Downloads the latest version of Axure RP 9 and creates a package.
+Identifier: com.github.smithjw.pkg.Axure_RP_9
+ParentRecipe: com.github.smithjw.download.Axure_RP_9
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Axure RP 9
+  SOFTWARE_TITLE: Axure_RP_9
+
+Process:
+  - Processor: PlistReader
+    Arguments:
+      info_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/Axure RP 9.app/Contents/Info.plist'
+      plist_keys:
+        CFBundleIdentifier: bundleid
+        CFBundleName: app_name
+        CFBundleVersion: version
+
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%pathname%/Axure RP 9.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/Axure/Axure_RP_9.upload.jamf.recipe.yaml
+++ b/Axure/Axure_RP_9.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Axure_RP_9
+ParentRecipe: com.github.smithjw.pkg.Axure_RP_9
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Axure RP 9
+  SOFTWARE_TITLE: Axure_RP_9
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-9'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Azul/AzulZuluJavaInfoProvider.py
+++ b/Azul/AzulZuluJavaInfoProvider.py
@@ -1,0 +1,128 @@
+#!/usr/local/autopkg/python
+#
+# Copyright 2022 David Pirie
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""See docstring for AzulZuluJavaInfoProvider class"""
+
+import json
+
+from autopkglib import ProcessorError
+from autopkglib.URLGetter import URLGetter
+
+__all__ = ["AzulZuluJavaInfoProvider"]
+
+DEFAULT_API_URL = "https://www.azul.com/wp-admin/admin-ajax.php?action=bundles&endpoint=community&use_stage=false&include_fields=java_version,openjdk_build_number,os,arch,bundle_type,javafx,latest,ext,name,sha256_hash,url"
+DEFAULT_JAVA_MAJOR_VERSION = 7
+DEFAULT_ARCH = "x86"
+DEFAULT_EXTENSION = "dmg"
+DEFAULT_BUNDLE_TYPE = "jre"
+
+SUPPORTED_ARCHS = ["x86", "arm"]
+SUPPORTED_EXTENSIONS = ["zip", "tar.gz", "dmg"]
+SUPPORTED_BUNDLE_TYPES = ["jre", "jdk", "jre_fx", "jdk_fx"]
+
+MUNKI_ARCHS = {"x86": "x86_64", "arm": "arm64"}
+
+
+class AzulZuluJavaInfoProvider(URLGetter):
+    """Provides URL to the latest Azul Zulu Java release."""
+
+    description = __doc__
+    input_variables = {
+        "api_url": {
+            "required": False,
+            "description": f"URL for the api endpoint to {DEFAULT_API_URL}",
+        },
+        "java_major_version": {
+            "required": False,
+            "description": f"Major version of Java. Defaults to {DEFAULT_JAVA_MAJOR_VERSION}",
+        },
+        "arch": {
+            "required": False,
+            "description": f"Hardware architecture. Currently supports: {', '.join(SUPPORTED_ARCHS)}. Defaults to {DEFAULT_ARCH}.",
+        },
+        "extension": {
+            "required": False,
+            "description": f"Download file extension. Currently supports: {', '.join(SUPPORTED_EXTENSIONS)}. Defaults to {DEFAULT_EXTENSION}.",
+        },
+        "bundle_type": {
+            "required": False,
+            "description": f"Download bundle type. Currently supports: {', '.join(SUPPORTED_BUNDLE_TYPES)}. Defaults to {DEFAULT_BUNDLE_TYPE}.",
+        },
+    }
+    output_variables = {
+        "url": {"description": "URL to the latest Azul Zulu Java release."},
+        "version": {"description": "Azul Zulu version."},
+        "java_version": {"description": "Java version."},
+        "openjdk_build_number": {"description": "OpenJDK build number."},
+        "sha256_hash": {"description": "SHA256 hash for the download."},
+        "munki_arch": {
+            "description": "Architecture appropriate for the munki pkginfo key supported_architectures"
+        },
+    }
+
+    def main(self):
+        api_url = self.env.get("api_url", DEFAULT_API_URL)
+        java_major_version = self.env.get(
+            "java_major_version", DEFAULT_JAVA_MAJOR_VERSION
+        )
+        arch = self.env.get("arch", DEFAULT_ARCH)
+        if arch not in SUPPORTED_ARCHS:
+            raise ProcessorError(
+                f"arch {arch} not one of those supported: {', '.join(SUPPORTED_ARCHS)}."
+            )
+        extension = self.env.get("extension", DEFAULT_EXTENSION)
+        if extension not in SUPPORTED_EXTENSIONS:
+            raise ProcessorError(
+                f"extension {extension} not one of those supported: {', '.join(SUPPORTED_EXTENSIONS)}."
+            )
+        javafx = False
+        bundle_type = self.env.get("bundle_type", DEFAULT_BUNDLE_TYPE)
+        if bundle_type not in SUPPORTED_BUNDLE_TYPES:
+            raise ProcessorError(
+                f"bundle_type {bundle_type} not one of those supported: {', '.join(SUPPORTED_BUNDLE_TYPES)}."
+            )
+        if bundle_type.endswith("_fx"):
+            bundle_type = bundle_type[:-3]
+            javafx = True
+
+        source_files = json.loads(self.download(api_url, text=True))
+        for source_file in source_files:
+            if (
+                source_file["latest"]
+                and source_file["os"] == "macos"
+                and str(source_file["java_version"][0]) == java_major_version
+                and source_file["arch"] == arch
+                and source_file["ext"] == extension
+                and source_file["bundle_type"] == bundle_type
+                and source_file["javafx"] == javafx
+            ):
+                data = source_file
+                break
+        else:
+            raise ProcessorError(
+                f"No source file found matching the requested criteria of java_major_version={java_major_version}, arch={arch}, extension={extension}, bundle_type={bundle_type}, javafx={javafx}"
+            )
+        self.env["url"] = data["url"]
+        self.env["version"] = ".".join([str(x) for x in data["zulu_version"]])
+        self.env["java_version"] = ".".join([str(x) for x in data["java_version"]])
+        self.env["openjdk_build_number"] = str(data["openjdk_build_number"])
+        self.env["sha256_hash"] = data["sha256_hash"]
+        self.env["munki_arch"] = MUNKI_ARCHS[arch]
+        self.output(f"Found URL {self.env['url']} for version {self.env['version']}")
+
+
+if __name__ == "__main__":
+    PROCESSOR = AzulZuluJavaInfoProvider()
+    PROCESSOR.execute_shell()

--- a/Azul/Azul_Zulu_JDK.download.recipe.yaml
+++ b/Azul/Azul_Zulu_JDK.download.recipe.yaml
@@ -1,0 +1,66 @@
+Comment: Valid versions are 11, 17, 21, 25, & 26
+Description: Downloads the latest release version of Azul Zulu Java for given Java version
+Identifier: com.github.smithjw.download.Azul_Zulu_JDK
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Azul Zulu JDK
+  SOFTWARE_TITLE: Azul_Zulu_JDK
+  JDK_VERSION: '26'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: AzulZuluJavaInfoProvider
+    Arguments:
+      arch: arm
+      bundle_type: jdk
+      extension: dmg
+      java_major_version: '%JDK_VERSION%'
+      request_headers:
+        user-agent: 'curl/8.7.1'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-%JDK_VERSION%-macos-arm64.dmg'
+
+  - Processor: AzulZuluJavaInfoProvider
+    Arguments:
+      arch: x86
+      bundle_type: jdk
+      extension: dmg
+      java_major_version: '%JDK_VERSION%'
+      request_headers:
+        user-agent: 'curl/8.7.1'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-%JDK_VERSION%-macos-x86_64.dmg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Azul Systems, Inc. (TDTHCUPYFR)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%JDK_VERSION%-macos-arm64.dmg/*.pkg'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Azul Systems, Inc. (TDTHCUPYFR)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%JDK_VERSION%-macos-x86_64.dmg/*.pkg'

--- a/Azul/Azul_Zulu_JDK.pkg.recipe.yaml
+++ b/Azul/Azul_Zulu_JDK.pkg.recipe.yaml
@@ -1,0 +1,82 @@
+Identifier: com.github.smithjw.pkg.Azul_Zulu_JDK
+ParentRecipe: com.github.smithjw.download.Azul_Zulu_JDK
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Azul Zulu JDK
+  SOFTWARE_TITLE: Azul_Zulu_JDK
+  JDK_VERSION: '24'
+
+Process:
+  - Processor: FlatPkgUnpacker
+    Arguments:
+      flat_pkg_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%JDK_VERSION%-macos-arm64.dmg/*.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+
+  - Processor: FileFinder
+    Arguments:
+      pattern: '%RECIPE_CACHE_DIR%/unpack/zulu*.pkg'
+
+  - Processor: PkgPayloadUnpacker
+    Arguments:
+      pkg_payload_path: '%found_filename%/Payload'
+      destination_path: '%RECIPE_CACHE_DIR%/payload'
+
+  - Processor: Versioner
+    Arguments:
+      input_plist_path: '%RECIPE_CACHE_DIR%/payload/Contents/Info.plist'
+      plist_version_key: CFBundleName
+
+  - Processor: com.github.jazzace.processors/TextSearcher
+    Arguments:
+      text_in: '%version%'
+      result_output_var_name: version
+      re_pattern: '(\d+\.\d+\.\d+$)'
+
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%JDK_VERSION%-macos-arm64.dmg/*.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-arm64.pkg'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%JDK_VERSION%-macos-x86_64.dmg/*.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-x86_64.pkg'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/sbin/installer -pkg %SOFTWARE_TITLE%-arm64.pkg -target /
+        else
+          /usr/sbin/installer -pkg %SOFTWARE_TITLE%-x86_64.pkg -target /
+        fi
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: com.azulsystems.zulu.%JDK_VERSION%
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'
+        - '%RECIPE_CACHE_DIR%/unpack'

--- a/Azul/Azul_Zulu_JDK.upload.jamf.recipe.yaml
+++ b/Azul/Azul_Zulu_JDK.upload.jamf.recipe.yaml
@@ -1,0 +1,31 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Azul_Zulu_JDK
+ParentRecipe: com.github.smithjw.pkg.Azul_Zulu_JDK
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Azul Zulu JDK
+  SOFTWARE_TITLE: Azul_Zulu_JDK
+  CATEGORY: Apps
+  JDK_VERSION: '24'
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-%JDK_VERSION%'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Brave_Browser/Brave_Browser.download.recipe.yaml
+++ b/Brave_Browser/Brave_Browser.download.recipe.yaml
@@ -1,0 +1,63 @@
+Description: |
+  Downloads Brave Browser and produces a verified artefact for downstream packaging.
+
+  Run as part of the full download → pkg → upload chain. The `URLDownloaderPython`
+  processor caches by ETag/Last-Modified/Content-Length and the
+  `StopProcessingIf download_changed == False` predicate short-circuits the chain
+  on no-op re-runs. Pointing the upload recipe at a pre-built pkg would defeat
+  this cache and re-upload on every CI run.
+
+  Brave publishes separate `arm64` and `x86_64` `.dmg` files — `Brave-Browser-arm64.dmg`
+  and `Brave-Browser.dmg` (Intel) — at `referrals.brave.com`. We pull both via
+  `laptop-updates.brave.com/latest/<arch>` (which 302s to the latest versioned dmg) so
+  the resulting pkg can install on either architecture (see Brave_Browser.pkg.recipe.yaml).
+Identifier: com.github.smithjw.download.Brave_Browser
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Brave Browser
+  SOFTWARE_TITLE: Brave_Browser
+  DOWNLOAD_URL_ARM64: https://laptop-updates.brave.com/latest/osxarm64
+  DOWNLOAD_URL_X86_64: https://laptop-updates.brave.com/latest/osx
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-arm64.dmg'
+      url: '%DOWNLOAD_URL_ARM64%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-x86_64.dmg'
+      url: '%DOWNLOAD_URL_X86_64%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  # Brave bundles a Sparkle.framework whose headers carry `com.apple.FinderInfo` xattrs.
+  # `strict_verification: true` rejects those as "resource fork / detritus not allowed"
+  # on macOS 14+, so strict is left off here. `deep_verification` is kept on (it passes)
+  # so nested code is still verified against the requirement string below.
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Brave Browser.app'
+      requirement: identifier "com.brave.Browser" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "KL8N8XSYF4"
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg/Brave Browser.app'
+      requirement: identifier "com.brave.Browser" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "KL8N8XSYF4"
+
+  - Processor: Versioner
+    Arguments:
+      input_plist_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Brave Browser.app/Contents/Info.plist'
+      plist_version_key: CFBundleShortVersionString

--- a/Brave_Browser/Brave_Browser.pkg.recipe.yaml
+++ b/Brave_Browser/Brave_Browser.pkg.recipe.yaml
@@ -1,0 +1,62 @@
+Description: |
+  Builds separate arm64 and x86_64 component packages, then wraps them in a
+  top-level installer whose postinstall script installs only the package that
+  matches the device architecture.
+Identifier: com.github.smithjw.pkg.Brave_Browser
+ParentRecipe: com.github.smithjw.download.Brave_Browser
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Brave Browser
+  SOFTWARE_TITLE: Brave_Browser
+
+Process:
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/wrapper'
+      pkgdirs:
+        pkgroot: '0755'
+        scripts: '0755'
+
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Brave Browser.app'
+      force_pkg_build: true
+      pkg_path: '%RECIPE_CACHE_DIR%/wrapper/scripts/%SOFTWARE_TITLE%-arm64.pkg'
+
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg/Brave Browser.app'
+      force_pkg_build: true
+      pkg_path: '%RECIPE_CACHE_DIR%/wrapper/scripts/%SOFTWARE_TITLE%-x86_64.pkg'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/wrapper/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        set -euo pipefail
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/sbin/installer -pkg "%SOFTWARE_TITLE%-arm64.pkg" -target "$3"
+        else
+          /usr/sbin/installer -pkg "%SOFTWARE_TITLE%-x86_64.pkg" -target "$3"
+        fi
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: '%bundleid%'
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/wrapper/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/wrapper/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/wrapper'

--- a/Brave_Browser/Brave_Browser.upload.jamf.recipe.yaml
+++ b/Brave_Browser/Brave_Browser.upload.jamf.recipe.yaml
@@ -1,0 +1,31 @@
+Description: |
+  Downloads the latest version of Brave Browser, packages it, and uploads to Jamf Pro.
+Identifier: com.github.smithjw.jamf.upload.Brave_Browser
+ParentRecipe: com.github.smithjw.pkg.Brave_Browser
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Brave Browser
+  SOFTWARE_TITLE: Brave_Browser
+  CATEGORY: Browsers
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Bruno/Bruno.download.recipe.yaml
+++ b/Bruno/Bruno.download.recipe.yaml
@@ -1,0 +1,40 @@
+Description: |
+  Downloads the most recent signed release pkg of Bruno from GitHub.
+
+  In order to get the latest pre-release, set the Input variable INCLUDE_PRERELEASES to a non-empty
+  string (such as 'True'; this is the default). If you just want the latest full release instead,
+  INCLUDE_PRERELEASES must be set to an empty string.
+Identifier: com.github.smithjw.download.Bruno
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Bruno
+  SOFTWARE_TITLE: '%NAME%'
+  INCLUDE_PRERELEASES: 'True'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: .*arm64_mac.dmg$
+      github_repo: usebruno/bruno
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.dmg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/Bruno.app'
+      requirement: identifier "com.usebruno.app" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = W7LPPWA48L
+      strict_verification: true

--- a/Bruno/Bruno.pkg.recipe.yaml
+++ b/Bruno/Bruno.pkg.recipe.yaml
@@ -1,0 +1,19 @@
+Description: |
+  Downloads the most recent signed release pkg of Bruno from GitHub.
+
+  In order to get the latest pre-release, set the Input variable INCLUDE_PRERELEASES to a non-empty
+  string (such as 'True'; this is the default). If you just want the latest full release instead,
+  INCLUDE_PRERELEASES must be set to an empty string.
+Identifier: com.github.smithjw.pkg.Bruno
+ParentRecipe: com.github.smithjw.download.Bruno
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Bruno
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/Bruno.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/Bruno/Bruno.upload.jamf.recipe.yaml
+++ b/Bruno/Bruno.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Downloads the latest version of Bruno, creates a package, then uploads to Jamf
+Identifier: com.github.smithjw.jamf.upload.Bruno
+ParentRecipe: com.github.smithjw.pkg.Bruno
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Bruno
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/CharlesProxy/CharlesProxy.download.recipe.yaml
+++ b/CharlesProxy/CharlesProxy.download.recipe.yaml
@@ -1,0 +1,43 @@
+Description: Downloads the current release version of CharlesProxy.
+Identifier: com.github.smithjw.download.CharlesProxy
+MinimumVersion: '2.9'
+
+Input:
+  NAME: CharlesProxy
+  SOFTWARE_TITLE: '%NAME%'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+  MAJOR_VERSION: '5'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: <h4>Version\s+(?P<version>%MAJOR_VERSION%\.\d+\.\d+)(?!b\d+).*?<\/h4>
+      request_headers:
+        user-agent: 'curl/8.7.1'
+      url: https://www.charlesproxy.com/documentation/version-history/
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      fetch_filename: true
+      url: https://www.charlesproxy.com/assets/release/%version%/charles-proxy-%version%.dmg
+      request_headers:
+        user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%pathname%/*.app'
+      requirement: |
+        identifier "com.xk72.Charles" and anchor apple generic and
+        certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and
+        certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and
+        certificate leaf[subject.OU] = "9A5PCU4FSD"

--- a/CharlesProxy/CharlesProxy.pkg.recipe.yaml
+++ b/CharlesProxy/CharlesProxy.pkg.recipe.yaml
@@ -1,0 +1,14 @@
+Description: Downloads the current release version of CharlesProxy and builds a package.
+Identifier: com.github.smithjw.pkg.CharlesProxy
+ParentRecipe: com.github.smithjw.download.CharlesProxy
+MinimumVersion: '2.9'
+
+Input:
+  NAME: CharlesProxy
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%pathname%/*.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/CharlesProxy/CharlesProxy.upload.jamf.recipe.yaml
+++ b/CharlesProxy/CharlesProxy.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.CharlesProxy
+ParentRecipe: com.github.smithjw.pkg.CharlesProxy
+MinimumVersion: '2.9'
+
+Input:
+  NAME: CharlesProxy
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Cirrus_Labs/tart.download.recipe.yaml
+++ b/Cirrus_Labs/tart.download.recipe.yaml
@@ -1,0 +1,36 @@
+Description: Downloads the latest version of tart from Github. Specifiy an ARCH of "arm64" for Apple Silicon or "amd64" for Intel.
+Identifier: com.github.smithjw.download.tart
+MinimumVersion: 2.4.1
+
+Input:
+  NAME: tart
+  SOFTWARE_TITLE: '%NAME%'
+  ARCH: arm64
+  GITHUB_REPO: cirruslabs/tart
+  INCLUDE_PRERELEASES: 'True'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: ^tart-%ARCH%.*?tar.gz$
+      github_repo: '%GITHUB_REPO%'
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.tar.gz'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%pathname%'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      purge_destination: true

--- a/Cirrus_Labs/tart.pkg.recipe.yaml
+++ b/Cirrus_Labs/tart.pkg.recipe.yaml
@@ -1,0 +1,70 @@
+Description: Downloads the latest version of tart from Github; pulls apart the package and checks the binary's code signature. Specifiy an ARCH of "arm64" for Apple Silicon or "amd64" for Intel.
+Identifier: com.github.smithjw.pkg.tart
+ParentRecipe: com.github.smithjw.download.tart
+MinimumVersion: 2.4.1
+
+Input:
+  NAME: tart
+  SOFTWARE_TITLE: '%NAME%'
+  ARCH: arm64
+  GITHUB_REPO: cirruslabs/tart
+  INCLUDE_PRERELEASES: 'true'
+
+Process:
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgdirs:
+        payload: '0775'
+        payload/Library: '0755'
+        payload/Library/Application Support: '0755'
+        payload/Library/Application Support/Tart: '0755'
+        scripts: '0775'
+      pkgroot: '%RECIPE_CACHE_DIR%/pkgroot'
+
+  - Processor: Copier
+    Arguments:
+      destination_path: '%RECIPE_CACHE_DIR%/pkgroot/payload/Library/Application Support/Tart/'
+      overwrite: true
+      source_path: '%RECIPE_CACHE_DIR%/unpack/'
+
+  - Processor: FileCreator
+    Arguments:
+      file_content: |
+        #!/bin/bash
+
+        set -e
+
+        # Remove existing symlink/executable
+        rm -rf /usr/local/bin/tart
+
+        # Create new executable
+        echo "#!/bin/sh" > /usr/local/bin/tart
+        echo "exec '/Library/Application Support/Tart/tart.app/Contents/MacOS/tart' \\"\\$@\\"" >> /usr/local/bin/tart
+
+        # Set permissions
+        chmod +x /usr/local/bin/tart
+      file_mode: '0755'
+      file_path: '%RECIPE_CACHE_DIR%/pkgroot/scripts/postinstall'
+
+  - Processor: PkgCreator
+    Arguments:
+      force_pkg_build: true
+      pkg_request:
+        chown:
+          - group: wheel
+            path: Library
+            user: root
+        id: com.github.cirruslabs.tart-app
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%ARCH%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/pkgroot/payload'
+        scripts: '%RECIPE_CACHE_DIR%/pkgroot/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/unpack'
+        - '%RECIPE_CACHE_DIR%/pkgroot'

--- a/Cirrus_Labs/tart.upload.jamf.recipe.yaml
+++ b/Cirrus_Labs/tart.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.tart
+ParentRecipe: com.github.smithjw.pkg.tart
+MinimumVersion: '2.9'
+
+Input:
+  NAME: tart
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Cisco/Webex.download.recipe.yaml
+++ b/Cisco/Webex.download.recipe.yaml
@@ -25,6 +25,8 @@ Process:
 
     - Processor: CodeSignatureVerifier
       Arguments:
+          deep_verification: true
+          strict_verification: true
           input_path: '%pathname%/Webex.app'
           requirement: identifier "Cisco-Systems.Spark" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = DE8Y96K9QP
 

--- a/Colour_Contrast_Analyser/Colour_Contrast_Analyser.download.recipe.yaml
+++ b/Colour_Contrast_Analyser/Colour_Contrast_Analyser.download.recipe.yaml
@@ -1,0 +1,33 @@
+Description: Downloads the latest version of Colour Contrast Analyser.
+Identifier: com.github.smithjw.download.Colour_Contrast_Analyser
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Colour Contrast Analyser
+  SOFTWARE_TITLE: Colour_Contrast_Analyser
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: .*.dmg
+      github_repo: ThePacielloGroup/CCAe
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      fetch_filename: true
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%pathname%/*.app'
+      requirement: identifier "com.electron.cca" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "34RS4UC3M6"

--- a/Colour_Contrast_Analyser/Colour_Contrast_Analyser.pkg.recipe.yaml
+++ b/Colour_Contrast_Analyser/Colour_Contrast_Analyser.pkg.recipe.yaml
@@ -1,0 +1,14 @@
+Description: Downloads the latest version of Colour Contrast Analyser and builds a package.
+Identifier: com.github.smithjw.pkg.Colour_Contrast_Analyser
+ParentRecipe: com.github.smithjw.download.Colour_Contrast_Analyser
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Colour Contrast Analyser
+  SOFTWARE_TITLE: Colour_Contrast_Analyser
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%pathname%/*.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/Colour_Contrast_Analyser/Colour_Contrast_Analyser.upload.jamf.recipe.yaml
+++ b/Colour_Contrast_Analyser/Colour_Contrast_Analyser.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Colour_Contrast_Analyser
+ParentRecipe: com.github.smithjw.pkg.Colour_Contrast_Analyser
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Colour Contrast Analyser
+  SOFTWARE_TITLE: Colour_Contrast_Analyser
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/DBeaver/DBeaver.download.recipe.yaml
+++ b/DBeaver/DBeaver.download.recipe.yaml
@@ -1,0 +1,59 @@
+Description: |
+  Downloads DBeaver and produces a verified artefact for downstream packaging.
+
+  Run as part of the full download → pkg → upload chain. The `URLDownloaderPython`
+  processor caches by ETag/Last-Modified/Content-Length and the
+  `StopProcessingIf download_changed == False` predicate short-circuits the chain
+  on no-op re-runs. Pointing the upload recipe at a pre-built pkg would defeat
+  this cache and re-upload on every CI run.
+
+  DBeaver publishes separate arm64 (`aarch64`) and Intel (`x86_64`) `.dmg` files. We pull
+  both so the resulting pkg can install on either architecture (see DBeaver.pkg.recipe.yaml).
+Identifier: com.github.smithjw.download.DBeaver
+MinimumVersion: '2.9'
+
+Input:
+  NAME: DBeaver
+  SOFTWARE_TITLE: DBeaver
+  DOWNLOAD_URL_ARM64: https://dbeaver.io/files/dbeaver-ce-latest-macos-aarch64.dmg
+  DOWNLOAD_URL_X86_64: https://dbeaver.io/files/dbeaver-ce-latest-macos-x86_64.dmg
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-arm64.dmg'
+      url: '%DOWNLOAD_URL_ARM64%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-x86_64.dmg'
+      url: '%DOWNLOAD_URL_X86_64%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/DBeaver.app'
+      requirement: identifier "org.jkiss.dbeaver.core.product" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "42B6MDKMW8"
+      strict_verification: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg/DBeaver.app'
+      requirement: identifier "org.jkiss.dbeaver.core.product" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "42B6MDKMW8"
+      strict_verification: true
+
+  - Processor: Versioner
+    Arguments:
+      input_plist_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/DBeaver.app/Contents/Info.plist'
+      plist_version_key: CFBundleShortVersionString

--- a/DBeaver/DBeaver.pkg.recipe.yaml
+++ b/DBeaver/DBeaver.pkg.recipe.yaml
@@ -1,0 +1,62 @@
+Description: |
+  Builds separate arm64 and x86_64 component packages, then wraps them in a
+  top-level installer whose postinstall script installs only the package that
+  matches the device architecture.
+Identifier: com.github.smithjw.pkg.DBeaver
+ParentRecipe: com.github.smithjw.download.DBeaver
+MinimumVersion: '2.9'
+
+Input:
+  NAME: DBeaver
+  SOFTWARE_TITLE: DBeaver
+
+Process:
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/wrapper'
+      pkgdirs:
+        pkgroot: '0755'
+        scripts: '0755'
+
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/DBeaver.app'
+      force_pkg_build: true
+      pkg_path: '%RECIPE_CACHE_DIR%/wrapper/scripts/%SOFTWARE_TITLE%-arm64.pkg'
+
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg/DBeaver.app'
+      force_pkg_build: true
+      pkg_path: '%RECIPE_CACHE_DIR%/wrapper/scripts/%SOFTWARE_TITLE%-x86_64.pkg'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/wrapper/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        set -euo pipefail
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/sbin/installer -pkg "%SOFTWARE_TITLE%-arm64.pkg" -target "$3"
+        else
+          /usr/sbin/installer -pkg "%SOFTWARE_TITLE%-x86_64.pkg" -target "$3"
+        fi
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: '%bundleid%'
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/wrapper/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/wrapper/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/wrapper'

--- a/DBeaver/DBeaver.upload.jamf.recipe.yaml
+++ b/DBeaver/DBeaver.upload.jamf.recipe.yaml
@@ -1,0 +1,31 @@
+Description: |
+  Downloads the latest version of DBeaver, packages it, and uploads to Jamf Pro.
+Identifier: com.github.smithjw.jamf.upload.DBeaver
+ParentRecipe: com.github.smithjw.pkg.DBeaver
+MinimumVersion: '2.9'
+
+Input:
+  NAME: DBeaver
+  SOFTWARE_TITLE: DBeaver
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/DisplayLink/DisplayLink_Manager.download.recipe.yaml
+++ b/DisplayLink/DisplayLink_Manager.download.recipe.yaml
@@ -37,6 +37,8 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       expected_authority_names:
         - 'Developer ID Installer: DisplayLink Corp (73YQY62QM3)'
         - Developer ID Certification Authority

--- a/Elgato/Stream_Deck.download.recipe.yaml
+++ b/Elgato/Stream_Deck.download.recipe.yaml
@@ -1,0 +1,32 @@
+Description: Downloads the latest version of Stream Deck.
+Identifier: com.github.smithjw.download.Stream_Deck
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Stream Deck
+  SOFTWARE_TITLE: Stream_Deck
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.pkg'
+      url: https://gc-updates.elgato.com/mac/sd-update/final/download-website.php
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Corsair Memory, Inc. (Y93VXCB8Q5)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/Elgato/Stream_Deck.pkg.recipe.yaml
+++ b/Elgato/Stream_Deck.pkg.recipe.yaml
@@ -1,0 +1,32 @@
+Description: Downloads the latest version of Stream Deck and creates a package.
+Identifier: com.github.smithjw.pkg.Stream_Deck
+ParentRecipe: com.github.smithjw.download.Stream_Deck
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Stream Deck
+  SOFTWARE_TITLE: Stream_Deck
+
+Process:
+  - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
+    Arguments:
+      archive_path: '%pathname%'
+      file_to_extract: Distribution
+
+  - Processor: com.github.mlbz521.SharedProcessors/XPathParser
+    Arguments:
+      attribute_one: version
+      return_variable_attribute_one: version
+      xml_file: '%extracted_file%'
+      xpath: .//pkg-ref[@id="com.elgato.StreamDeck"][@version]
+
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/extractedfile'

--- a/Elgato/Stream_Deck.upload.jamf.recipe.yaml
+++ b/Elgato/Stream_Deck.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Stream_Deck
+ParentRecipe: com.github.smithjw.pkg.Stream_Deck
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Stream Deck
+  SOFTWARE_TITLE: Stream_Deck
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/FileZilla/FileZilla.download.recipe.yaml
+++ b/FileZilla/FileZilla.download.recipe.yaml
@@ -1,0 +1,39 @@
+Description: Downloads the current version of FileZilla.
+Identifier: com.github.smithjw.download.FileZilla
+MinimumVersion: '2.9'
+
+Input:
+  NAME: FileZilla
+  SOFTWARE_TITLE: '%NAME%'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: <a href="(?P<url>http[s]?.*?(?P<filename>FileZilla_(?P<version>[\d.]+)_macos-x86.*?\.tar\.bz2).*?)"
+      request_headers:
+        user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15
+      url: https://filezilla-project.org/download.php?show_all=1
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      purge_destination: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/unpack/FileZilla.app'
+      requirement: identifier "org.filezilla-project.filezilla" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5VPGKXL75N"

--- a/FileZilla/FileZilla.pkg.recipe.yaml
+++ b/FileZilla/FileZilla.pkg.recipe.yaml
@@ -1,0 +1,20 @@
+Description: Downloads the current version of FileZilla and creates a package.
+Identifier: com.github.smithjw.pkg.FileZilla
+ParentRecipe: com.github.smithjw.download.FileZilla
+MinimumVersion: '2.9'
+
+Input:
+  NAME: FileZilla
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/unpack/FileZilla.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/unpack'

--- a/FileZilla/FileZilla.upload.jamf.recipe.yaml
+++ b/FileZilla/FileZilla.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.FileZilla
+ParentRecipe: com.github.smithjw.pkg.FileZilla
+MinimumVersion: '2.9'
+
+Input:
+  NAME: FileZilla
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Fork/Fork.download.recipe.yaml
+++ b/Fork/Fork.download.recipe.yaml
@@ -1,0 +1,32 @@
+Description: Downloads the latest release version of Fork.
+Identifier: com.github.smithjw.download.Fork
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Fork
+  SOFTWARE_TITLE: '%NAME%'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: (?P<url>https://.*?Fork-(?P<version>[0-9]+\.[0-9]+\.[0-9]+)\.dmg)
+      url: https://fork.dev
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%pathname%/Fork.app'
+      requirement: anchor apple generic and identifier "com.DanPristupov.Fork" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Q6M7LEEA66)

--- a/Fork/Fork.pkg.recipe.yaml
+++ b/Fork/Fork.pkg.recipe.yaml
@@ -1,0 +1,19 @@
+Description: Downloads the latest release version of Fork and creates an installer package.
+Identifier: com.github.smithjw.pkg.Fork
+ParentRecipe: com.github.smithjw.download.Fork
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Fork
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/unpack'

--- a/Fork/Fork.upload.jamf.recipe.yaml
+++ b/Fork/Fork.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Fork
+ParentRecipe: com.github.smithjw.pkg.Fork
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Fork
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Freelens/Freelens.download.recipe.yaml
+++ b/Freelens/Freelens.download.recipe.yaml
@@ -1,0 +1,56 @@
+Description: Downloads the latest Freelens release packages from GitHub.
+Identifier: com.github.smithjw.download.Freelens
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Freelens
+  SOFTWARE_TITLE: Freelens
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: .*macos-arm64\.pkg$
+      github_repo: freelensapp/freelens
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-arm64.pkg'
+
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: .*macos-amd64\.pkg$
+      github_repo: freelensapp/freelens
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-x86_64.pkg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: ROBERTO BANDINI (TFR6NT55MB)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.pkg'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: ROBERTO BANDINI (TFR6NT55MB)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.pkg'

--- a/Freelens/Freelens.pkg.recipe.yaml
+++ b/Freelens/Freelens.pkg.recipe.yaml
@@ -1,0 +1,56 @@
+Description: Downloads the FreeLens PKG from GitHub releases.
+Identifier: com.github.smithjw.pkg.Freelens
+ParentRecipe: com.github.smithjw.download.Freelens
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Freelens
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-arm64.pkg'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-x86_64.pkg'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/sbin/installer -pkg "%SOFTWARE_TITLE%-arm64.pkg" -target "$3"
+        else
+          /usr/sbin/installer -pkg "%SOFTWARE_TITLE%-x86_64.pkg" -target "$3"
+        fi
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: app.freelens.Freelens
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/Freelens/Freelens.upload.jamf.recipe.yaml
+++ b/Freelens/Freelens.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Uploads the latest version of Freelens package to Jamf
+Identifier: com.github.smithjw.jamf.upload.Freelens
+ParentRecipe: com.github.smithjw.pkg.Freelens
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Freelens
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '4'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Ghostty/Ghostty.download.recipe.yaml
+++ b/Ghostty/Ghostty.download.recipe.yaml
@@ -44,5 +44,7 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%pathname%/Ghostty.app'
       requirement: identifier "com.mitchellh.ghostty" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "24VZTF6M5V"

--- a/GitHub/GitHub_Desktop.download.recipe.yaml
+++ b/GitHub/GitHub_Desktop.download.recipe.yaml
@@ -43,6 +43,8 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%RECIPE_CACHE_DIR%/unpack/GitHub Desktop.app'
       requirement: '(identifier "com.github.GitHub" or identifier "com.github.GHAskPass") and anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VEKTX9H2N7'
 

--- a/Google/Google_Chrome.download.recipe.yaml
+++ b/Google/Google_Chrome.download.recipe.yaml
@@ -24,6 +24,7 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
       strict_verification: true
       requirement: (identifier "com.google.Chrome" or identifier "com.google.Chrome.beta" or identifier "com.google.Chrome.dev" or identifier "com.google.Chrome.canary") and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV
       input_path: '%pathname%'

--- a/HashiCorp/HashiCorpURLProvider.py
+++ b/HashiCorp/HashiCorpURLProvider.py
@@ -1,0 +1,108 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import json
+import re
+from distutils.version import LooseVersion
+
+from autopkglib import Processor, ProcessorError, URLGetter
+
+__all__ = ["HashiCorpURLProvider"]
+
+RELEASES_BASE_URL = "https://releases.hashicorp.com"
+DEFAULT_OS = "darwin"
+DEFAULT_ARCH = "all"
+RELEASE_RE = re.compile(r'^[0-9\.]+$')
+
+
+class HashiCorpURLProvider(URLGetter):
+    """Provides a download URL for a HashiCorp project using their releases API"""
+    input_variables = {
+        "project_name": {
+            "required": True,
+            "description": "The name of the HashiCorp project to get. "
+            "Possible values are listed at https://releases.hashicorp.com",
+        },
+        "os": {
+            "required": False,
+            "description": "",
+        },
+        "arch": {
+            "required": False,
+            "description": "Architecture to get: 386, amd64, arm",
+        },
+    }
+    output_variables = {
+        "url": {
+            "description": "URL to the latest project release.",
+        },
+        "version": {
+            "description": "URL to the latest project release.",
+        },
+    }
+    description = __doc__
+
+    def download_releases_info(self, base_url):
+        """Downloads the update url and returns a json object"""
+        f = self.download(base_url, None)
+        try:
+            json_data = json.loads(f)
+        except (ValueError, KeyError, TypeError) as e:
+            self.output("JSON response was: %s" % f)
+            raise ProcessorError("JSON format error: %s" % e)
+
+        return json_data
+
+    def get_project_url(self, base_url, operating_system, architecture):
+        """Find and return a download URL"""
+        # Download a JSON with all releases
+        releases = self.download_releases_info(base_url)
+        # print(json.dumps(releases, sort_keys=True, indent=4, separators=(',', ': ')))
+
+        # Sort versions with LooseVersion and get a dictionary for the latest version
+        versions = releases.get('versions', None)
+        version_numbers = versions.keys()
+        release_numbers = [ v for v in version_numbers if RELEASE_RE.match(v) ]
+        release_numbers.sort(key=LooseVersion, reverse=True)
+        latest_version = versions[release_numbers[0]]
+        # print(json.dumps(latest_version, sort_keys=True, indent=4, separators=(',', ': ')))
+
+        # Set the version variable
+        self.env["version"] = latest_version.get('version', None)
+
+        # Go through the builds and get the os and arch specific download URL
+        builds = latest_version.get('builds', [])
+        found_build = next((build for build in builds if build['os'] == operating_system and build['arch'] == architecture), None)
+        if found_build:
+            source_url = found_build.get('url', None)
+            if not source_url:
+                raise ProcessorError("No URL found for os: %s, arch: %s" % (operating_system, architecture))
+            return source_url
+        else:
+            raise ProcessorError("No build for os: %s, arch: %s" % (operating_system, architecture))
+
+    def main(self):
+        project_name = self.env.get("project_name")
+        operating_system = self.env.get("os", DEFAULT_OS)
+        architecture = self.env.get("arch", DEFAULT_ARCH)
+        base_url = "/".join([RELEASES_BASE_URL, project_name, "index.json"])
+        self.env["url"] = self.get_project_url(base_url, operating_system, architecture)
+        self.output("Found URL %s" % self.env["url"])
+
+
+if __name__ == "__main__":
+    PROCESSOR = HashiCorpURLProvider()
+    PROCESSOR.execute_shell()

--- a/HashiCorp/HashiCorp_Vault.download.recipe.yaml
+++ b/HashiCorp/HashiCorp_Vault.download.recipe.yaml
@@ -1,0 +1,72 @@
+Description: Downloads the latest HashiCorp Vault.
+Identifier: com.github.smithjw.download.HashiCorp_Vault
+MinimumVersion: '2.9'
+
+Input:
+  NAME: HashiCorp Vault
+  SOFTWARE_TITLE: HashiCorp_Vault
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: HashiCorpURLProvider
+    Arguments:
+      arch: arm64
+      os: darwin
+      project_name: vault
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-arm64.zip'
+
+  - Processor: HashiCorpURLProvider
+    Arguments:
+      arch: amd64
+      os: darwin
+      project_name: vault
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-x86_64.zip'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.zip'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack/arm64'
+      purge_destination: true
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.zip'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack/x86_64'
+      purge_destination: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/unpack/arm64/vault'
+      requirement: >-
+        identifier vault and anchor apple generic and
+        certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and
+        certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and
+        certificate leaf[subject.OU] = D38WU7D763
+      strict_verification: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/unpack/x86_64/vault'
+      requirement: >-
+        identifier vault and anchor apple generic and
+        certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and
+        certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and
+        certificate leaf[subject.OU] = D38WU7D763

--- a/HashiCorp/HashiCorp_Vault.pkg.recipe.yaml
+++ b/HashiCorp/HashiCorp_Vault.pkg.recipe.yaml
@@ -1,0 +1,59 @@
+Description: Downloads the latest Vault.
+Identifier: com.github.smithjw.pkg.HashiCorp_Vault
+ParentRecipe: com.github.smithjw.download.HashiCorp_Vault
+MinimumVersion: '2.9'
+
+Input:
+  NAME: HashiCorp Vault
+  SOFTWARE_TITLE: HashiCorp_Vault
+
+Process:
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: FileMover
+    Arguments:
+      source: '%RECIPE_CACHE_DIR%/unpack/arm64/vault'
+      target: '%RECIPE_CACHE_DIR%/payload/scripts/vault-arm64'
+
+  - Processor: FileMover
+    Arguments:
+      source: '%RECIPE_CACHE_DIR%/unpack/x86_64/vault'
+      target: '%RECIPE_CACHE_DIR%/payload/scripts/vault-x86_64'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /bin/mv vault-arm64 /usr/local/bin/vault
+        else
+          /bin/mv vault-x86_64 /usr/local/bin/vault
+        fi
+        /bin/chmod 0755 /usr/local/bin/vault
+        /bin/chown root:wheel /usr/local/bin/vault
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: com.hashicorp.vault
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'
+        - '%RECIPE_CACHE_DIR%/unpack'

--- a/HashiCorp/HashiCorp_Vault.upload.jamf.recipe.yaml
+++ b/HashiCorp/HashiCorp_Vault.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Downloads and extracts the vault binary, create pkg and upload to jamf
+Identifier: com.github.smithjw.jamf.upload.HashiCorp_Vault
+ParentRecipe: com.github.smithjw.pkg.HashiCorp_Vault
+MinimumVersion: '2.9'
+
+Input:
+  NAME: HashiCorp Vault
+  SOFTWARE_TITLE: HashiCorp_Vault
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Jamf_Connect/Jamf_Connect.download.recipe.yaml
+++ b/Jamf_Connect/Jamf_Connect.download.recipe.yaml
@@ -1,0 +1,34 @@
+Comment: ''
+Description: Downloads latest Jamf Connect package.
+Identifier: com.github.smithjw.download.Jamf_Connect
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Jamf Connect
+  SOFTWARE_TITLE: Jamf_Connect
+  DOWNLOAD_URL: https://files.jamfconnect.com/JamfConnect.dmg
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.dmg'
+      url: '%DOWNLOAD_URL%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: JAMF Software (483DWKW443)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%/JamfConnectLogin.pkg'

--- a/Jamf_Connect/Jamf_Connect.pkg.recipe.yaml
+++ b/Jamf_Connect/Jamf_Connect.pkg.recipe.yaml
@@ -1,0 +1,33 @@
+Comment: ''
+Description: Downloads latest Jamf Connect DMG and extracts the pkg.
+Identifier: com.github.smithjw.pkg.Jamf_Connect
+ParentRecipe: com.github.smithjw.download.Jamf_Connect
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Jamf Connect
+  SOFTWARE_TITLE: Jamf_Connect
+
+Process:
+  - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
+    Arguments:
+      archive_path: '%pathname%/JamfConnectLogin.pkg'
+      file_to_extract: Distribution
+
+  - Processor: com.github.mlbz521.SharedProcessors/XPathParser
+    Arguments:
+      attribute_one: version
+      return_variable_attribute_one: version
+      xml_file: '%extracted_file%'
+      xpath: ./pkg-ref[@id="com.jamf.connect.login"]
+
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%/JamfConnectLogin.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/extractedfile'

--- a/Jamf_Connect/Jamf_Connect.upload.jamf.recipe.yaml
+++ b/Jamf_Connect/Jamf_Connect.upload.jamf.recipe.yaml
@@ -1,0 +1,44 @@
+Description: |
+  Downloads the most recent DMG of Jamf Connect and uploads it to your Jamf Pro instance.
+Identifier: com.github.smithjw.jamf.upload.Jamf_Connect
+ParentRecipe: com.github.smithjw.pkg.Jamf_Connect
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Jamf Connect
+  SOFTWARE_TITLE: Jamf_Connect
+  CATEGORY: Utilities
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+  SCRIPT_NAME: jamf_connect_launchagent.sh
+  SCRIPT_PARAMETER_4_VALUE: unused
+  SCRIPT_PARAMETER_5_VALUE: unused
+  SCRIPT_PARAMETER_6_VALUE: unused
+  SCRIPT_PRIORITY: After
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfScriptUploader
+    Arguments:
+      replace_script: true
+      script_category: autopkg
+      script_path: jamf_connect_launchagent.sh
+      script_priority: After
+      skip_script_key_substitution: true
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Jamf_Protect/Jamf_Protect.download.recipe.yaml
+++ b/Jamf_Protect/Jamf_Protect.download.recipe.yaml
@@ -1,0 +1,43 @@
+Comment: Jamf does not provide a public download URL, so you will need to create a recipe override and enter the URL and UUID Jamf provides into the DOWNLOAD_URL and DOWNLOAD_UUID values of the override.
+Description: Download recipe for Jamf Protect's installer from a Jamf Protect tenant.
+Identifier: com.github.smithjw.download.Jamf_Protect
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Jamf Protect
+  SOFTWARE_TITLE: Jamf_Protect
+  DOWNLOAD_UUID: Override_Jamf_Protect_Package_UUID_Here
+  DOWNLOAD_URL: Override_Jamf_Protect_Package_URL_Here
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: DOWNLOAD_URL == "Override_Jamf_Protect_Package_URL_Here"
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: DOWNLOAD_UUID == "Override_Jamf_Protect_Package_UUID_Here"
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.pkg'
+      url: '%DOWNLOAD_URL%?%DOWNLOAD_UUID%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: JAMF Software (483DWKW443)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/Jamf_Protect/Jamf_Protect.pkg.recipe.yaml
+++ b/Jamf_Protect/Jamf_Protect.pkg.recipe.yaml
@@ -1,0 +1,32 @@
+Description: Downloads the current Jamf Protect installer, extracts version information and renames the installer package.
+Identifier: com.github.smithjw.pkg.Jamf_Protect
+ParentRecipe: com.github.smithjw.download.Jamf_Protect
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Jamf Protect
+  SOFTWARE_TITLE: Jamf_Protect
+
+Process:
+  - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
+    Arguments:
+      archive_path: '%pathname%'
+      file_to_extract: Distribution
+
+  - Processor: com.github.mlbz521.SharedProcessors/XPathParser
+    Arguments:
+      attribute_one: version
+      return_variable_attribute_one: version
+      xml_file: '%extracted_file%'
+      xpath: .//pkg-ref[@id="com.jamf.protect.pkg"][@version]
+
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/extractedfile'

--- a/Jamf_Protect/Jamf_Protect.upload.jamf.recipe.yaml
+++ b/Jamf_Protect/Jamf_Protect.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Downloads the most recent Jamf Protect version and uploads it to your Jamf Pro instance.
+Identifier: com.github.smithjw.jamf.upload.Jamf_Protect
+ParentRecipe: com.github.smithjw.pkg.Jamf_Protect
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Jamf Protect
+  SOFTWARE_TITLE: Jamf_Protect
+  CATEGORY: Utilities
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Jamf_Setup_Manager/Jamf_Setup_Manager.download.recipe.yaml
+++ b/Jamf_Setup_Manager/Jamf_Setup_Manager.download.recipe.yaml
@@ -1,0 +1,37 @@
+Description: ''
+Identifier: com.github.smithjw.download.Jamf_Setup_Manager
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Jamf Setup Manager
+  SOFTWARE_TITLE: Jamf_Setup_Manager
+  INCLUDE_PRERELEASES: 'True'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      github_repo: Jamf-Concepts/Setup-Manager
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: JAMF Software (483DWKW443)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/Jamf_Setup_Manager/Jamf_Setup_Manager.pkg.recipe.yaml
+++ b/Jamf_Setup_Manager/Jamf_Setup_Manager.pkg.recipe.yaml
@@ -1,0 +1,14 @@
+Description: ''
+Identifier: com.github.smithjw.pkg.Jamf_Setup_Manager
+ParentRecipe: com.github.smithjw.download.Jamf_Setup_Manager
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Jamf Setup Manager
+  SOFTWARE_TITLE: Jamf_Setup_Manager
+
+Process:
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%'

--- a/Jamf_Setup_Manager/Jamf_Setup_Manager.upload.jamf.recipe.yaml
+++ b/Jamf_Setup_Manager/Jamf_Setup_Manager.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Jamf_Setup_Manager
+ParentRecipe: com.github.smithjw.pkg.Jamf_Setup_Manager
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Jamf Setup Manager
+  SOFTWARE_TITLE: Jamf_Setup_Manager
+  CATEGORY: Utilities
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Kap/Kap.download.recipe.yaml
+++ b/Kap/Kap.download.recipe.yaml
@@ -23,5 +23,7 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%pathname%/Kap.app'
       requirement: identifier "com.wulkano.kap" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2KEEHXF6R6"

--- a/Logitech/Logi_Options_Plus.download.recipe.yaml
+++ b/Logitech/Logi_Options_Plus.download.recipe.yaml
@@ -1,0 +1,44 @@
+Description: |
+  Downloads the latest verison of Logitech Options Plus Offline installer
+  https://prosupport.logi.com/hc/en-gb/articles/6046882446359-Mass-installation-and-configuration-of-Logitech-Options-software#h.k97ihcogiap9
+Identifier: com.github.smithjw.download.logi_options_plus
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Logi Options+
+  SOFTWARE_TITLE: logi_options_plus
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.zip'
+      url: https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer_offline.zip
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      purge_destination: true
+
+  - Processor: FileFinder
+    Arguments:
+      pattern: '%RECIPE_CACHE_DIR%/unpack/**.app'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%found_filename%'
+      requirement: >-
+        identifier "com.logi.optionsplus.installer" and anchor apple generic and
+        certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and
+        certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and
+        certificate leaf[subject.OU] = QED4VVPZWA

--- a/Logitech/Logi_Options_Plus.pkg.recipe.yaml
+++ b/Logitech/Logi_Options_Plus.pkg.recipe.yaml
@@ -1,0 +1,71 @@
+Description: |
+  Downloads the latest verison of Logitech Options Plus Offline installer and creates a package.
+  https://prosupport.logi.com/hc/en-gb/articles/6046882446359-Mass-installation-and-configuration-of-Logitech-Options-software#h.k97ihcogiap9
+Identifier: com.github.smithjw.pkg.logi_options_plus
+ParentRecipe: com.github.smithjw.download.logi_options_plus
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Logi Options+
+  SOFTWARE_TITLE: logi_options_plus
+
+Process:
+  - Processor: PlistReader
+    Arguments:
+      info_path: '%found_filename%/Contents/Info.plist'
+      plist_keys:
+        CFBundleVersion: version
+        CFBundleIdentifier: bundleid
+        CFBundleName: app_name
+
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%found_filename%'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/logioptionsplus_installer_offline.app'
+
+  - Processor: FileCreator
+    Arguments:
+      file_mode: '0755'
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_content: |
+        #!/bin/bash
+
+        logioptionsplus_installer_offline.app/Contents/MacOS/logioptionsplus_installer \
+          --actions-ring no \
+          --aipromptbuilder no \
+          --analytics no \
+          --device-recommendation no \
+          --flow no \
+          --logivoice no \
+          --quiet \
+          --smartactions no \
+          --sso no \
+          --update no
+
+        exitcode=$?
+        exit "${exitcode}"
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: '%bundleid%'
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/unpack'
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/Logitech/Logi_Options_Plus.upload.jamf.recipe.yaml
+++ b/Logitech/Logi_Options_Plus.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Downloads the current version of Logi Options+ and updates the package version
+Identifier: com.github.smithjw.jamf.upload.logi_options_plus
+ParentRecipe: com.github.smithjw.pkg.logi_options_plus
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Logi Options+
+  SOFTWARE_TITLE: logi_options_plus
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '4'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/MacPass/MacPass.download.recipe.yaml
+++ b/MacPass/MacPass.download.recipe.yaml
@@ -1,0 +1,38 @@
+Description: Downloads the latest version of MacPass.
+Identifier: com.github.smithjw.download.MacPass
+MinimumVersion: '2.9'
+
+Input:
+  NAME: MacPass
+  SOFTWARE_TITLE: '%NAME%'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: (MacPass-[\d\.]+\.zip)
+      github_repo: MacPass/MacPass
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%pathname%'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      purge_destination: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/unpack/MacPass.app'
+      requirement: anchor apple generic and identifier "com.hicknhacksoftware.MacPass" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "55SM4L4Z97")

--- a/MacPass/MacPass.pkg.recipe.yaml
+++ b/MacPass/MacPass.pkg.recipe.yaml
@@ -1,0 +1,20 @@
+Description: Downloads the latest version of MacPass and creates an installer package.
+Identifier: com.github.smithjw.pkg.MacPass
+ParentRecipe: com.github.smithjw.download.MacPass
+MinimumVersion: '2.9'
+
+Input:
+  NAME: MacPass
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/unpack/MacPass.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/unpack'

--- a/MacPass/MacPass.upload.jamf.recipe.yaml
+++ b/MacPass/MacPass.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.MacPass
+ParentRecipe: com.github.smithjw.pkg.MacPass
+MinimumVersion: '2.9'
+
+Input:
+  NAME: MacPass
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Mac_Admins_Python/Mac_Admins_Python.download.recipe.yaml
+++ b/Mac_Admins_Python/Mac_Admins_Python.download.recipe.yaml
@@ -1,0 +1,43 @@
+Description: |
+  Downloads the most recent signed release pkg of macadmins/python from GitHub.
+
+  In order to get the latest pre-release, set the Input variable INCLUDE_PRERELEASES to a non-empty
+  string (such as 'True'; this is the default). If you just want the latest full release instead,
+  INCLUDE_PRERELEASES must be set to an empty string.
+Identifier: com.github.smithjw.download.Mac_Admins_Python
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Mac Admins Python
+  SOFTWARE_TITLE: Mac_Admins_Python
+  INCLUDE_PRERELEASES: 'True'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: python_recommended_signed-[\d.]+.pkg
+      github_repo: macadmins/python
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.pkg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/Mac_Admins_Python/Mac_Admins_Python.pkg.recipe.yaml
+++ b/Mac_Admins_Python/Mac_Admins_Python.pkg.recipe.yaml
@@ -1,0 +1,14 @@
+Description: Downloads the most recent signed release pkg of Mac Admins Python from GitHub and renames the package.
+Identifier: com.github.smithjw.pkg.Mac_Admins_Python
+ParentRecipe: com.github.smithjw.download.Mac_Admins_Python
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Mac Admins Python
+  SOFTWARE_TITLE: Mac_Admins_Python
+
+Process:
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%'

--- a/Mac_Admins_Python/Mac_Admins_Python.upload.jamf.recipe.yaml
+++ b/Mac_Admins_Python/Mac_Admins_Python.upload.jamf.recipe.yaml
@@ -1,0 +1,36 @@
+Description: |
+  Downloads the most recent signed release pkg of macadmins/python from GitHub and
+  uploads it to your Jamf Pro instance.
+
+  In order to get the latest pre-release, set the Input variable INCLUDE_PRERELEASES to a non-empty
+  string (such as 'True'; this is the default). If you just want the latest full release instead,
+  INCLUDE_PRERELEASES must be set to an empty string.
+Identifier: com.github.smithjw.jamf.upload.Mac_Admins_Python
+ParentRecipe: com.github.smithjw.pkg.Mac_Admins_Python
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Mac Admins Python
+  SOFTWARE_TITLE: Mac_Admins_Python
+  CATEGORY: Utilities
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Maccy/Maccy.download.recipe.yaml
+++ b/Maccy/Maccy.download.recipe.yaml
@@ -1,0 +1,38 @@
+Description: Downloads the latest version of Maccy.
+Identifier: com.github.smithjw.download.Maccy
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Maccy
+  SOFTWARE_TITLE: '%NAME%'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: (Maccy.app.zip)
+      github_repo: p0deje/Maccy
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%pathname%'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      purge_destination: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/unpack/Maccy.app'
+      requirement: anchor apple generic and identifier "org.p0deje.Maccy" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MN3X4648SC)

--- a/Maccy/Maccy.pkg.recipe.yaml
+++ b/Maccy/Maccy.pkg.recipe.yaml
@@ -1,0 +1,20 @@
+Description: Downloads the latest version of Maccy and creates an installer package.
+Identifier: com.github.smithjw.pkg.Maccy
+ParentRecipe: com.github.smithjw.download.Maccy
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Maccy
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/unpack/Maccy.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/unpack'

--- a/Maccy/Maccy.upload.jamf.recipe.yaml
+++ b/Maccy/Maccy.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Maccy
+ParentRecipe: com.github.smithjw.pkg.Maccy
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Maccy
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Microsoft/Microsoft_Package.download.recipe.yaml
+++ b/Microsoft/Microsoft_Package.download.recipe.yaml
@@ -29,6 +29,8 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       expected_authority_names:
         - 'Developer ID Installer: Microsoft Corporation (UBF8T346G9)'
         - Developer ID Certification Authority

--- a/Microsoft_NET/dotnet.download.recipe.yaml
+++ b/Microsoft_NET/dotnet.download.recipe.yaml
@@ -1,0 +1,73 @@
+Description: Downloads Microsoft .NET SDK
+Identifier: com.github.smithjw.download.dotnet
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Microsoft .NET
+  SOFTWARE_TITLE: microsoft_dotnet
+  SDK_VERSION: '9'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: href="(/en-us/download/dotnet/thank-you/sdk-%SDK_VERSION%\..*-macos-arm64-installer)"
+      result_output_var_name: arm_installer
+      url: https://dotnet.microsoft.com/en-us/download/dotnet/%SDK_VERSION%.0
+
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: id="directLink" href="(https://.*/dotnet-sdk-.*-osx-arm64\.pkg)" aria-label
+      result_output_var_name: arm_direct_download
+      url: 'https://dotnet.microsoft.com%arm_installer%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-%SDK_VERSION%-arm64.pkg'
+      url: '%arm_direct_download%'
+
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: href="(/en-us/download/dotnet/thank-you/sdk-%SDK_VERSION%\..*-macos-x64-installer)"
+      result_output_var_name: intel_installer
+      url: https://dotnet.microsoft.com/en-us/download/dotnet/%SDK_VERSION%.0
+
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: id="directLink" href="(https://.*/dotnet-sdk-.*-osx-x64\.pkg)" aria-label
+      result_output_var_name: intel_direct_download
+      url: 'https://dotnet.microsoft.com%intel_installer%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-%SDK_VERSION%-x86_64.pkg'
+      url: '%intel_direct_download%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Microsoft Corporation (UBF8T346G9)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%SDK_VERSION%-arm64.pkg'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Microsoft Corporation (UBF8T346G9)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%SDK_VERSION%-x86_64.pkg'

--- a/Microsoft_NET/dotnet.pkg.recipe.yaml
+++ b/Microsoft_NET/dotnet.pkg.recipe.yaml
@@ -1,0 +1,69 @@
+Description: Packages Microsoft .NET SDK
+Identifier: com.github.smithjw.pkg.dotnet
+ParentRecipe: com.github.smithjw.download.dotnet
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Microsoft .NET
+  SOFTWARE_TITLE: microsoft_dotnet
+  SDK_VERSION: '9'
+
+Process:
+  - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
+    Arguments:
+      archive_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%SDK_VERSION%-arm64.pkg'
+      file_to_extract: Distribution
+
+  - Processor: com.github.mlbz521.SharedProcessors/XPathParser
+    Arguments:
+      attribute_one: version
+      return_variable_attribute_one: version
+      xml_file: '%extracted_file%'
+      xpath: .//product[@version]
+
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%SDK_VERSION%-arm64.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-%SDK_VERSION%-arm64.pkg'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-%SDK_VERSION%-x86_64.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-%SDK_VERSION%-x86_64.pkg'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/sbin/installer -pkg %SOFTWARE_TITLE%-%SDK_VERSION%-arm64.pkg -target /
+        else
+          /usr/sbin/installer -pkg %SOFTWARE_TITLE%-%SDK_VERSION%-x86_64.pkg -target /
+        fi
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: com.microsoft.dotnet
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/Microsoft_NET/dotnet.upload.jamf.recipe.yaml
+++ b/Microsoft_NET/dotnet.upload.jamf.recipe.yaml
@@ -1,0 +1,31 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.dotnet
+ParentRecipe: com.github.smithjw.pkg.dotnet
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Microsoft .NET
+  SOFTWARE_TITLE: microsoft_dotnet
+  SDK_VERSION: '9'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-%SDK_VERSION%'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Microsoft_Office_Reset/Office_Reset.download.recipe.yaml
+++ b/Microsoft_Office_Reset/Office_Reset.download.recipe.yaml
@@ -39,6 +39,8 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       expected_authority_names:
         - 'Developer ID Installer: Paul Bowden (QGS93ZLCU7)'
         - Developer ID Certification Authority

--- a/MySQL/MySQLWorkbench.download.recipe.yaml
+++ b/MySQL/MySQLWorkbench.download.recipe.yaml
@@ -1,0 +1,46 @@
+Description: Downloads the latest version of MySQL Workbench for macOS. Downloads both the ARM and Intel builds.
+Identifier: com.github.smithjw.download.MySQLWorkbench
+MinimumVersion: '2.9'
+
+Input:
+  NAME: MySQLWorkbench
+  SOFTWARE_TITLE: '%NAME%'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      url: https://dev.mysql.com/downloads/workbench
+      re_pattern: (?P<dmg>mysql-workbench-community-(?P<version>[\d\.]+))
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      prefetch_filename: true
+      url: https://dev.mysql.com/get/Downloads/MySQLGUITools/mysql-workbench-community-%version%-macos-arm64.dmg
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      prefetch_filename: true
+      url: https://dev.mysql.com/get/Downloads/MySQLGUITools/mysql-workbench-community-%version%-macos-x86_64.dmg
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/mysql-workbench-community-%version%-macos-arm64.dmg/MySQLWorkbench.app'
+      requirement: identifier "com.oracle.workbench.MySQLWorkbench" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VB5E2TV963
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/mysql-workbench-community-%version%-macos-x86_64.dmg/MySQLWorkbench.app'
+      requirement: identifier "com.oracle.workbench.MySQLWorkbench" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VB5E2TV963

--- a/MySQL/MySQLWorkbench.pkg.recipe.yaml
+++ b/MySQL/MySQLWorkbench.pkg.recipe.yaml
@@ -1,0 +1,66 @@
+Description: Downloads the latest version of MySQL Workbench for macOS and creates an installer package.
+Identifier: com.github.smithjw.pkg.MySQLWorkbench
+ParentRecipe: com.github.smithjw.download.MySQLWorkbench
+MinimumVersion: '2.9'
+
+Input:
+  NAME: MySQLWorkbench
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/mysql-workbench-community-%version%-macos-arm64.dmg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/MySQLWorkbench-arm64.dmg'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/mysql-workbench-community-%version%-macos-x86_64.dmg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/MySQLWorkbench-x86_64.dmg'
+
+  - Processor: PlistReader
+    Arguments:
+      info_path: '%RECIPE_CACHE_DIR%/downloads/mysql-workbench-community-%version%-macos-arm64.dmg/MySQLWorkbench.app/Contents/Info.plist'
+      plist_keys:
+        CFBundleIdentifier: bundleid
+        CFBundleName: app_name
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/bin/hdiutil attach "MySQLWorkbench-arm64.dmg" -mountpoint "/Volumes/MySQLWorkbench" -nobrowse
+        else
+          /usr/bin/hdiutil attach "MySQLWorkbench-x86_64.dmg" -mountpoint "/Volumes/MySQLWorkbench" -nobrowse
+        fi
+
+        /bin/cp -R "/Volumes/MySQLWorkbench/MySQLWorkbench.app" "/Applications/MySQLWorkbench.app"
+        /usr/bin/hdiutil detach "/Volumes/MySQLWorkbench"
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: '%bundleid%'
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/MySQL/MySQLWorkbench.upload.jamf.recipe.yaml
+++ b/MySQL/MySQLWorkbench.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.MySQLWorkbench
+ParentRecipe: com.github.smithjw.pkg.MySQLWorkbench
+MinimumVersion: '2.9'
+
+Input:
+  NAME: MySQLWorkbench
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Neo4j/Neo4j_Desktop_2.download.recipe.yaml
+++ b/Neo4j/Neo4j_Desktop_2.download.recipe.yaml
@@ -1,0 +1,39 @@
+Identifier: com.github.smithjw.download.Neo4j_Desktop_2
+Description: Downloads the latest version of Neo4j Desktop for macOS.
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Neo4j Desktop 2
+  SOFTWARE_TITLE: Neo4j_Desktop_2
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      url: https://neo4j.com/deployment-center
+      re_pattern: 'data-url="/download/neo4j-desktop/\?edition=desktop&flavour=osx&release=(\d+\.\d+\.\d+)&offline=false"'
+      result_output_var_name: version
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.dmg'
+      url: https://neo4j.com/artifact.php?name=neo4j-desktop-2.%version%.dmg
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%pathname%/Neo4j Desktop 2.app'
+      requirement: >-
+        identifier "com.neo4j.neo4j-desktop-2" and anchor apple generic and
+        certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and
+        certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and
+        certificate leaf[subject.OU] = "8Z9BGNE3AV"

--- a/Neo4j/Neo4j_Desktop_2.pkg.recipe.yaml
+++ b/Neo4j/Neo4j_Desktop_2.pkg.recipe.yaml
@@ -1,0 +1,13 @@
+Description: Create a package from the Neo4j Desktop download.
+Identifier: com.github.smithjw.pkg.Neo4j_Desktop_2
+MinimumVersion: '2.9'
+ParentRecipe: com.github.smithjw.download.Neo4j_Desktop_2
+
+Input:
+  NAME: Neo4j Desktop 2
+  SOFTWARE_TITLE: Neo4j_Desktop_2
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/Neo4j/Neo4j_Desktop_2.upload.jamf.recipe.yaml
+++ b/Neo4j/Neo4j_Desktop_2.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Downloads the latest version of Neo4j Desktop, packages it, then uploads it to Jamf.
+Identifier: com.github.smithjw.jamf.upload.Neo4j_Desktop_2
+ParentRecipe: com.github.smithjw.pkg.Neo4j_Desktop_2
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Neo4j Desktop 2
+  SOFTWARE_TITLE: Neo4j_Desktop_2
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Nexthink/Nexthink_Collector.download.recipe.yaml
+++ b/Nexthink/Nexthink_Collector.download.recipe.yaml
@@ -1,0 +1,32 @@
+Description: Downloads the latest version of Nexthink Collector dmg
+Identifier: com.github.smithjw.download.Nexthink_Collector
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Nexthink Collector
+  SOFTWARE_TITLE: Nexthink_Collector
+  DOWNLOAD_URL: https://download.nexthink.com/releases/latest/OSX_Collector/Nexthink_Collector.dmg
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      filename: '%SOFTWARE_TITLE%.dmg'
+      url: '%DOWNLOAD_URL%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%pathname%/csi.app'
+      requirement: |
+        identifier "com.nexthink.collector.installer.csi" and
+        anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] and
+        certificate leaf[field.1.2.840.113635.100.6.1.13] and
+        certificate leaf[subject.OU] = PDEKAZ43QL

--- a/Nexthink/Nexthink_Collector.pkg.recipe.yaml
+++ b/Nexthink/Nexthink_Collector.pkg.recipe.yaml
@@ -1,0 +1,46 @@
+Description: Packages Nexthink Collector into /private/var/tmp/Nexthink/csi.app on managed devices
+Identifier: com.github.smithjw.pkg.Nexthink_Collector
+ParentRecipe: com.github.smithjw.download.Nexthink_Collector
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Nexthink Collector
+  SOFTWARE_TITLE: Nexthink_Collector
+
+Process:
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot/private/var/tmp/Nexthink: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%pathname%/csi.app'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/pkgroot/private/var/tmp/Nexthink/csi.app'
+
+  - Processor: PlistReader
+    Arguments:
+      info_path: '%RECIPE_CACHE_DIR%/payload/pkgroot/private/var/tmp/Nexthink/csi.app/Contents/Info.plist'
+      plist_keys:
+        CFBundleShortVersionString: version
+        CFBundleIdentifier: bundleid
+        CFBundleName: app_name
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: '%bundleid%'
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/Nexthink/Nexthink_Collector.upload.jamf.recipe.yaml
+++ b/Nexthink/Nexthink_Collector.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Downloads and extracts Nexthink Collector (csi.app), for distribution via Jamf into /private/var/tmp/Nexthink on managed devices
+Identifier: com.github.smithjw.jamf.upload.Nexthink_Collector
+ParentRecipe: com.github.smithjw.pkg.Nexthink_Collector
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Nexthink Collector
+  SOFTWARE_TITLE: Nexthink_Collector
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Nexthink/Nexthink_Collector_Uninstaller.pkg.recipe.yaml
+++ b/Nexthink/Nexthink_Collector_Uninstaller.pkg.recipe.yaml
@@ -1,0 +1,76 @@
+Description: Downloads the latest NexThink Collector uninstaller and prepares it for deployment.
+Identifier: com.github.smithjw.pkg.Nexthink_Collector_Uninstaller
+ParentRecipe: com.github.smithjw.download.Nexthink_Collector
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Nexthink Collector Uninstaller
+  SOFTWARE_TITLE: Nexthink_Collector_Uninstaller
+
+Process:
+  - Processor: PlistReader
+    Arguments:
+      info_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/csi.app/Contents/Info.plist'
+      plist_keys:
+        CFBundleShortVersionString: version
+        CFBundleIdentifier: bundleid
+        CFBundleName: app_name
+
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%.dmg'
+      purge_destination: true
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        # Description: Script to uninstall Nexthink Collector.
+        ERROR=0
+
+        # File Paths
+        if [[ -f "$(/usr/bin/find $(dirname $0) -maxdepth 1 \( -iname \*\.dmg \))" ]]; then
+          dmgFile="$(/usr/bin/find $(dirname $0) -maxdepth 1 \( -iname \*\.dmg \))"
+        fi
+
+        dmgMount="$(/usr/bin/mktemp -d /tmp/Nexthink_Collector_Uninstaller.XXXX)"
+
+        # Remove the trailing slash from the dmgMount variable if needed.
+        dmgMount=${dmgMount%%/}
+
+        # Mount the DMG
+        /usr/bin/hdiutil attach "$dmgFile" -mountpoint "$dmgMount" -nobrowse -noverify -noautoopen
+
+        # Uninstall the NexThink Collector software
+        "$dmgMount"/uninstaller
+
+        # Unmount the DMG
+        hdiutil detach "$dmgMount" -force
+
+        exit "$ERROR"
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: com.nexthink.collector.uninstaller
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/Nexthink/Nexthink_Collector_Uninstaller.upload.jamf.recipe.yaml
+++ b/Nexthink/Nexthink_Collector_Uninstaller.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Downloads and extracts Nexthink Collector Uninstaller package and uploads it to Jamf Pro.
+Identifier: com.github.smithjw.jamf.upload.Nexthink_Collector_Uninstaller
+ParentRecipe: com.github.smithjw.pkg.Nexthink_Collector_Uninstaller
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Nexthink Collector Uninstaller
+  SOFTWARE_TITLE: Nexthink_Collector_Uninstaller
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Node.js/node.download.recipe.yaml
+++ b/Node.js/node.download.recipe.yaml
@@ -1,0 +1,37 @@
+Description: Downloads the latest version of Node.js
+Identifier: com.github.smithjw.download.node
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Node.js
+  SOFTWARE_TITLE: node
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: node-v([0-9]+(\.[0-9]+)+)\.pkg
+      result_output_var_name: version
+      url: https://nodejs.org/dist/latest/
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      url: https://nodejs.org/dist/latest/node-v%version%.pkg
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Node.js Foundation (HX7739G8FX)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/Node.js/node.pkg.recipe.yaml
+++ b/Node.js/node.pkg.recipe.yaml
@@ -1,0 +1,14 @@
+Description: Downloads the latest version of Node.js and creates an installer package.
+Identifier: com.github.smithjw.pkg.node
+ParentRecipe: com.github.smithjw.download.node
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Node.js
+  SOFTWARE_TITLE: node
+
+Process:
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%'

--- a/Node.js/node.upload.jamf.recipe.yaml
+++ b/Node.js/node.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.node
+ParentRecipe: com.github.smithjw.pkg.node
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Node.js
+  SOFTWARE_TITLE: node
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/OBS_Studio/OBS_Studio.download.recipe.yaml
+++ b/OBS_Studio/OBS_Studio.download.recipe.yaml
@@ -1,0 +1,68 @@
+Description: |
+  Downloads OBS Studio and produces a verified artefact for downstream packaging.
+
+  Run as part of the full download → pkg → upload chain. The `URLDownloaderPython`
+  processor caches by ETag/Last-Modified/Content-Length and the
+  `StopProcessingIf download_changed == False` predicate short-circuits the chain
+  on no-op re-runs. Pointing the upload recipe at a pre-built pkg would defeat
+  this cache and re-upload on every CI run.
+
+  OBS publishes separate Apple-silicon (`macOS-Apple.dmg`) and Intel (`macOS-Intel.dmg`)
+  `.dmg` files; we pull both so the resulting pkg can install on either architecture
+  (see OBS_Studio.pkg.recipe.yaml).
+Identifier: com.github.smithjw.download.OBS_Studio
+MinimumVersion: '2.9'
+
+Input:
+  NAME: OBS Studio
+  SOFTWARE_TITLE: OBS_Studio
+  INCLUDE_PRERELEASES: null
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: 'OBS-Studio-[\d.]+-macOS-Apple\.dmg'
+      github_repo: obsproject/obs-studio
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-arm64.dmg'
+
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: 'OBS-Studio-[\d.]+-macOS-Intel\.dmg'
+      github_repo: obsproject/obs-studio
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-x86_64.dmg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  # OBS uses an OR clause in its designated requirement; we use a simpler form here
+  # (bundle-id + Team-ID match). deep + strict verification are both enabled and
+  # currently pass (unlike Brave, OBS's bundled frameworks carry no disallowed
+  # FinderInfo xattrs on the verified build).
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/OBS.app'
+      requirement: identifier "com.obsproject.obs-studio" and anchor apple generic and certificate leaf[subject.OU] = "2MMRE5MTB8"
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg/OBS.app'
+      requirement: identifier "com.obsproject.obs-studio" and anchor apple generic and certificate leaf[subject.OU] = "2MMRE5MTB8"

--- a/OBS_Studio/OBS_Studio.pkg.recipe.yaml
+++ b/OBS_Studio/OBS_Studio.pkg.recipe.yaml
@@ -1,0 +1,62 @@
+Description: |
+  Builds separate arm64 and x86_64 component packages, then wraps them in a
+  top-level installer whose postinstall script installs only the package that
+  matches the device architecture.
+Identifier: com.github.smithjw.pkg.OBS_Studio
+ParentRecipe: com.github.smithjw.download.OBS_Studio
+MinimumVersion: '2.9'
+
+Input:
+  NAME: OBS Studio
+  SOFTWARE_TITLE: OBS_Studio
+
+Process:
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/wrapper'
+      pkgdirs:
+        pkgroot: '0755'
+        scripts: '0755'
+
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/OBS.app'
+      force_pkg_build: true
+      pkg_path: '%RECIPE_CACHE_DIR%/wrapper/scripts/%SOFTWARE_TITLE%-arm64.pkg'
+
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg/OBS.app'
+      force_pkg_build: true
+      pkg_path: '%RECIPE_CACHE_DIR%/wrapper/scripts/%SOFTWARE_TITLE%-x86_64.pkg'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/wrapper/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        set -euo pipefail
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/sbin/installer -pkg "%SOFTWARE_TITLE%-arm64.pkg" -target "$3"
+        else
+          /usr/sbin/installer -pkg "%SOFTWARE_TITLE%-x86_64.pkg" -target "$3"
+        fi
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: '%bundleid%'
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/wrapper/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/wrapper/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/wrapper'

--- a/OBS_Studio/OBS_Studio.upload.jamf.recipe.yaml
+++ b/OBS_Studio/OBS_Studio.upload.jamf.recipe.yaml
@@ -1,0 +1,31 @@
+Description: |
+  Downloads the latest version of OBS Studio, packages it, and uploads to Jamf Pro.
+Identifier: com.github.smithjw.jamf.upload.OBS_Studio
+ParentRecipe: com.github.smithjw.pkg.OBS_Studio
+MinimumVersion: '2.9'
+
+Input:
+  NAME: OBS Studio
+  SOFTWARE_TITLE: OBS_Studio
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Obsidian/Obsidian.download.recipe.yaml
+++ b/Obsidian/Obsidian.download.recipe.yaml
@@ -1,0 +1,45 @@
+Description: |
+  Downloads Obsidian and produces a verified artefact for downstream packaging.
+
+  Run as part of the full download → pkg → upload chain. The `URLDownloaderPython`
+  processor caches by ETag/Last-Modified/Content-Length and the
+  `StopProcessingIf download_changed == False` predicate short-circuits the chain
+  on no-op re-runs. Pointing the upload recipe at a pre-built pkg would defeat
+  this cache and re-upload on every CI run.
+
+  Downloads the most recent signed release dmg of Obsidian from GitHub.
+  Obsidian ships universal builds; we pull the universal `.dmg`.
+Identifier: com.github.smithjw.download.Obsidian
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Obsidian
+  SOFTWARE_TITLE: Obsidian
+  INCLUDE_PRERELEASES: null
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: 'Obsidian-[\d.]+\.dmg'
+      github_repo: obsidianmd/obsidian-releases
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.dmg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/Obsidian.app'
+      requirement: identifier "md.obsidian" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6JSW4SJWN9"
+      strict_verification: true

--- a/Obsidian/Obsidian.pkg.recipe.yaml
+++ b/Obsidian/Obsidian.pkg.recipe.yaml
@@ -1,0 +1,15 @@
+Description: |
+  Wraps the downloaded Obsidian.app into an installer pkg.
+Identifier: com.github.smithjw.pkg.Obsidian
+ParentRecipe: com.github.smithjw.download.Obsidian
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Obsidian
+  SOFTWARE_TITLE: Obsidian
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/Obsidian.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/Obsidian/Obsidian.upload.jamf.recipe.yaml
+++ b/Obsidian/Obsidian.upload.jamf.recipe.yaml
@@ -1,0 +1,31 @@
+Description: |
+  Downloads the latest version of Obsidian, packages it, and uploads to Jamf Pro.
+Identifier: com.github.smithjw.jamf.upload.Obsidian
+ParentRecipe: com.github.smithjw.pkg.Obsidian
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Obsidian
+  SOFTWARE_TITLE: Obsidian
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Ollama/Ollama.download.recipe.yaml
+++ b/Ollama/Ollama.download.recipe.yaml
@@ -1,0 +1,51 @@
+Description: |
+  Downloads Ollama and produces a verified artefact for downstream packaging.
+
+  Run as part of the full download → pkg → upload chain. The `URLDownloaderPython`
+  processor caches by ETag/Last-Modified/Content-Length and the
+  `StopProcessingIf download_changed == False` predicate short-circuits the chain
+  on no-op re-runs. Pointing the upload recipe at a pre-built pkg would defeat
+  this cache and re-upload on every CI run.
+
+  Downloads the most recent signed release of Ollama (local LLM runner) from the vendor's
+  static URL.
+Identifier: com.github.smithjw.download.Ollama
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Ollama
+  SOFTWARE_TITLE: Ollama
+  DOWNLOAD_URL: https://ollama.com/download/Ollama-darwin.zip
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.zip'
+      url: '%DOWNLOAD_URL%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%pathname%'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      purge_destination: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/unpack/Ollama.app'
+      requirement: identifier "com.electron.ollama" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "94KV3E626L"
+      strict_verification: true
+
+  - Processor: Versioner
+    Arguments:
+      input_plist_path: '%RECIPE_CACHE_DIR%/unpack/Ollama.app/Contents/Info.plist'
+      plist_version_key: CFBundleShortVersionString

--- a/Ollama/Ollama.pkg.recipe.yaml
+++ b/Ollama/Ollama.pkg.recipe.yaml
@@ -1,0 +1,21 @@
+Description: |
+  Wraps the unpacked Ollama.app into an installer pkg.
+Identifier: com.github.smithjw.pkg.Ollama
+ParentRecipe: com.github.smithjw.download.Ollama
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Ollama
+  SOFTWARE_TITLE: Ollama
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/unpack/Ollama.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/unpack'

--- a/Ollama/Ollama.upload.jamf.recipe.yaml
+++ b/Ollama/Ollama.upload.jamf.recipe.yaml
@@ -1,0 +1,31 @@
+Description: |
+  Downloads the latest version of Ollama, packages it, and uploads to Jamf Pro.
+Identifier: com.github.smithjw.jamf.upload.Ollama
+ParentRecipe: com.github.smithjw.pkg.Ollama
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Ollama
+  SOFTWARE_TITLE: Ollama
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/OpenAI/Codex.download.recipe.yaml
+++ b/OpenAI/Codex.download.recipe.yaml
@@ -28,5 +28,7 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%pathname%/Codex.app'
       requirement: identifier "com.openai.codex" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2DC432GLL2"

--- a/OpenAI/Codex_CLI.download.recipe.yaml
+++ b/OpenAI/Codex_CLI.download.recipe.yaml
@@ -64,12 +64,14 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
       input_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-arm64/codex-aarch64-apple-darwin'
       requirement: identifier "codex" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2DC432GLL2"
       strict_verification: true
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
       input_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-x86_64/codex-x86_64-apple-darwin'
       requirement: identifier "codex" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2DC432GLL2"
       strict_verification: true

--- a/OpenCode/OpenCode.download.recipe.yaml
+++ b/OpenCode/OpenCode.download.recipe.yaml
@@ -30,5 +30,7 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%pathname%/OpenCode.app'
       requirement: identifier "ai.opencode.desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5NZ4Q7NXJ4"

--- a/Outset/Outset.download.recipe.yaml
+++ b/Outset/Outset.download.recipe.yaml
@@ -1,0 +1,37 @@
+Description: ''
+Identifier: com.github.smithjw.download.Outset
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Outset
+  SOFTWARE_TITLE: '%NAME%'
+  INCLUDE_PRERELEASES: 'True'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      github_repo: macadmins/outset
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.pkg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/Outset/Outset.pkg.recipe.yaml
+++ b/Outset/Outset.pkg.recipe.yaml
@@ -1,0 +1,14 @@
+Description: ''
+Identifier: com.github.smithjw.pkg.Outset
+ParentRecipe: com.github.smithjw.download.Outset
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Outset
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%'

--- a/Outset/Outset.upload.jamf.recipe.yaml
+++ b/Outset/Outset.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Outset
+ParentRecipe: com.github.smithjw.pkg.Outset
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Outset
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Utilities
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Palo_Alto/GlobalProtect.download.recipe.yaml
+++ b/Palo_Alto/GlobalProtect.download.recipe.yaml
@@ -1,0 +1,36 @@
+Description: ''
+Identifier: com.github.smithjw.download.GlobalProtect
+MinimumVersion: '2.9'
+
+Input:
+  NAME: GlobalProtect
+  SOFTWARE_TITLE: '%NAME%'
+  VERSION_SEARCH: null
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GlobalProtectVersionURLProvider
+    Arguments:
+      version_search: '%VERSION_SEARCH%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Palo Alto Networks (PXPZ95SK77)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/Palo_Alto/GlobalProtect.pkg.recipe.yaml
+++ b/Palo_Alto/GlobalProtect.pkg.recipe.yaml
@@ -1,0 +1,14 @@
+Description: ''
+Identifier: com.github.smithjw.pkg.GlobalProtect
+ParentRecipe: com.github.smithjw.download.GlobalProtect
+MinimumVersion: '2.9'
+
+Input:
+  NAME: GlobalProtect
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%'

--- a/Palo_Alto/GlobalProtect.upload.jamf.recipe.yaml
+++ b/Palo_Alto/GlobalProtect.upload.jamf.recipe.yaml
@@ -1,0 +1,41 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.GlobalProtect
+ParentRecipe: com.github.smithjw.pkg.GlobalProtect
+MinimumVersion: '2.9'
+
+Input:
+  NAME: GlobalProtect
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  SCRIPT_PARAMETER_4_VALUE: OVERRIDE_THIS_VALUE
+  SCRIPT_PARAMETER_5_VALUE: null
+  SCRIPT_PARAMETER_6_VALUE: null
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfScriptUploader
+    Arguments:
+      replace_script: true
+      script_parameter4: GlobalProtect Gateway
+      script_path: configure_globalprotect.sh
+      script_priority: Before
+      skip_script_key_substitution: true
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Palo_Alto/GlobalProtectVersionURLProvider.py
+++ b/Palo_Alto/GlobalProtectVersionURLProvider.py
@@ -1,0 +1,123 @@
+#!/usr/local/autopkg/python
+#
+# Copyright 2024 James Smith based on work by Allister Banks, & Hannes Juutilainen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import xml.etree.ElementTree as ET
+from operator import itemgetter
+
+from autopkglib import APLooseVersion, ProcessorError, URLGetter
+
+__all__ = ["GlobalProtectVersionURLProvider"]
+
+FEED_URL = "https://pan-gp-client.s3.amazonaws.com"
+
+
+class GlobalProtectVersionURLProvider(URLGetter):
+    """Provides the version and download URL for the Palo Alto Global Protect Client"""
+
+    input_variables = {
+        "feed_url": {"required": False, "description": f"Default is {FEED_URL}"},
+        "version_search": {
+            "required": False,
+            "description": "Set the version you'd like to find for GlobalProtect (if left blank, defaults to latest)",
+        },
+    }
+    output_variables = {
+        "version": {"description": "Version number for this release of GlobalProtect"},
+        "url": {"description": "URL for the found release of GlobalProtect"},
+    }
+    description = __doc__
+
+    def fetch_gp_versions(self, feed_url):
+        """Parse the Palo Alto S3 Bucket where GlobalProtect installers are hosted for the latest or defined version"""
+        try:
+            xml = self.download(feed_url)
+        except Exception as e:
+            raise ProcessorError(f"Can't download {feed_url}: {e}") from e
+
+        ns = {"ns": "http://s3.amazonaws.com/doc/2006-03-01/"}
+        root = ET.fromstring(xml)
+
+        gp_version_array = [
+            {
+                "version": key.split("/")[0],
+                "url": f"{feed_url}/{key}",
+            }
+            for content in root.findall("ns:Contents", ns)
+            if (key := content.find("ns:Key", ns).text).endswith(".pkg")
+        ]
+
+        # # Extract specific version from each dict within in the list
+        sorted_gp_version_array = sorted(
+            gp_version_array, key=lambda a: APLooseVersion(a["version"]), reverse=True
+        )
+
+        self.output(f"GP Versions Found: {sorted_gp_version_array}", verbose_level=4)
+        return sorted_gp_version_array
+
+    def find_closest_version(self, gp_version_list, version_search):
+        if not version_search:
+            self.output("Version not set, looking for latest version", verbose_level=3)
+            gp_version = max(gp_version_list, key=itemgetter("version"))
+            return gp_version
+
+        version_search = APLooseVersion(version_search)
+
+        for gp_version in gp_version_list:
+            version = APLooseVersion(gp_version["version"])
+            if version == version_search:
+                return gp_version
+
+        # If exact match isn't found, find the highest version that matches
+        matching_versions = [
+            gp_version
+            for gp_version in gp_version_list
+            if gp_version["version"].startswith(version_search.vstring)
+        ]
+
+        if not matching_versions:
+            matching_versions = [
+                gp_version
+                for gp_version in gp_version_list
+                if gp_version["version"].startswith(
+                    version_search.vstring.split("-", 1)[0]
+                )
+            ]
+
+        if matching_versions:
+            return max(matching_versions, key=lambda a: APLooseVersion(a["version"]))
+
+        return max(gp_version_list, key=itemgetter("version"))
+
+    def autopkg_output(self, name, value):
+        self.env[name] = value
+        self.output(f"Setting {name}: {value}")
+
+    def main(self):
+        feed_url = self.env.get("feed_url", FEED_URL)
+        version_search = self.env.get("version_search", None)
+
+        gp_version_list = self.fetch_gp_versions(feed_url)
+        gp = self.find_closest_version(gp_version_list, version_search)
+
+        self.autopkg_output("version", gp.get("version"))
+        self.autopkg_output("url", gp.get("url"))
+
+
+if __name__ == "__main__":
+    processor = GlobalProtectVersionURLProvider()
+    processor.execute_shell()

--- a/Palo_Alto/GlobalProtect_no_script.upload.jamf.recipe.yaml
+++ b/Palo_Alto/GlobalProtect_no_script.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.GlobalProtect_no_script
+ParentRecipe: com.github.smithjw.pkg.GlobalProtect
+MinimumVersion: '2.9'
+
+Input:
+  NAME: GlobalProtect
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/PostgresApp/PostgresApp.download.recipe.yaml
+++ b/PostgresApp/PostgresApp.download.recipe.yaml
@@ -45,5 +45,7 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%pathname%/Postgres.app'
       requirement: identifier "com.postgresapp.Postgres2" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "ZF84SJ5A3G"

--- a/Principle/Principle.download.recipe.yaml
+++ b/Principle/Principle.download.recipe.yaml
@@ -1,0 +1,47 @@
+Description: Downloads the latest version of Principle.
+Identifier: com.github.smithjw.download.Principle
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Principle
+  SOFTWARE_TITLE: '$NAME%'
+  SPARKLE_FEED_URL: https://principleformac.com/update2.xml
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: SparkleUpdateInfoProvider
+    Arguments:
+      appcast_url: '%SPARKLE_FEED_URL%'
+
+  - Processor: FindAndReplace
+    Arguments:
+      input_string: '%url%'
+      find: 'http://'
+      replace: 'https://'
+      result_output_var_name: url
+      appcast_url: '%SPARKLE_FEED_URL%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      fetch_filename: true
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%pathname%'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      purge_destination: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/unpack/*.app'
+      requirement: anchor apple generic and identifier "com.danielhooper.principle" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JWLPBZ6FYH)

--- a/Principle/Principle.pkg.recipe.yaml
+++ b/Principle/Principle.pkg.recipe.yaml
@@ -1,0 +1,20 @@
+Description: Downloads Principle and makes a pkg of it.
+Identifier: com.github.smithjw.pkg.Principle
+ParentRecipe: com.github.smithjw.download.Principle
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Principle
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/unpack/*.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/unpack'

--- a/Principle/Principle.upload.jamf.recipe.yaml
+++ b/Principle/Principle.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Principle
+ParentRecipe: com.github.smithjw.pkg.Principle
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Principle
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Privileges/Privileges.download.recipe.yaml
+++ b/Privileges/Privileges.download.recipe.yaml
@@ -1,0 +1,37 @@
+Description: ''
+Identifier: com.github.smithjw.download.Privileges
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Privileges
+  SOFTWARE_TITLE: Privileges
+  INCLUDE_PRERELEASES: null
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      github_repo: SAP/macOS-enterprise-privileges
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: SAP SE (7R5ZEU67FQ)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/Privileges/Privileges.pkg.recipe.yaml
+++ b/Privileges/Privileges.pkg.recipe.yaml
@@ -1,0 +1,14 @@
+Description: ''
+Identifier: com.github.smithjw.pkg.Privileges
+ParentRecipe: com.github.smithjw.download.Privileges
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Privileges
+  SOFTWARE_TITLE: Privileges
+
+Process:
+  - Processor: PkgCopier
+    Arguments:
+      source_pkg: '%pathname%'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/Privileges/Privileges.upload.jamf.recipe.yaml
+++ b/Privileges/Privileges.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Privileges
+ParentRecipe: com.github.smithjw.pkg.Privileges
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Privileges
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Utilities
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Python/Python.download.recipe.yaml
+++ b/Python/Python.download.recipe.yaml
@@ -1,0 +1,42 @@
+Description: |
+  Downloads the latest or specified version of Python 3. Stable builds are checked first, then pre-release builds.
+  Options:
+    - To download the latest version of Python 3, use (this is REGEX): \\d+
+    - To download a specific minor version, use: "3.10"
+    - You can download a pre-release build if the minor version does not yet have a stable release.
+  This recipe sets the env variable `version_major_minor` for use in child recipes.
+Identifier: com.github.smithjw.download.Python
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Python
+  SOFTWARE_TITLE: Python
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: (?P<url>https://.*/python-(?P<version>(\d.)?\d+\.[\d]+).*\.pkg)
+      url: https://www.python.org/downloads/macos/
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      fetch_filename: true
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Python Software Foundation (BMM5U3QVKW)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/Python/Python.pkg.recipe.yaml
+++ b/Python/Python.pkg.recipe.yaml
@@ -1,0 +1,14 @@
+Description: Downloads the latest version of Python 3 and creates an installer package.
+Identifier: com.github.smithjw.pkg.Python
+ParentRecipe: com.github.smithjw.download.Python
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Python
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: PkgCopier
+    Arguments:
+      source_pkg: '%pathname%'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/Python/Python.upload.jamf.recipe.yaml
+++ b/Python/Python.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Python
+ParentRecipe: com.github.smithjw.pkg.Python
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Python
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Rectangle/Rectangle.download.recipe.yaml
+++ b/Rectangle/Rectangle.download.recipe.yaml
@@ -1,0 +1,45 @@
+Description: |
+  Downloads Rectangle and produces a verified artefact for downstream packaging.
+
+  Run as part of the full download → pkg → upload chain. The `URLDownloaderPython`
+  processor caches by ETag/Last-Modified/Content-Length and the
+  `StopProcessingIf download_changed == False` predicate short-circuits the chain
+  on no-op re-runs. Pointing the upload recipe at a pre-built pkg would defeat
+  this cache and re-upload on every CI run.
+
+  Rectangle ships its `.dmg` containing `Rectangle.app` and a separate `.pkg` per release.
+  We pull the `.dmg`, verify `Rectangle.app`, and let the pkg recipe wrap it.
+Identifier: com.github.smithjw.download.Rectangle
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Rectangle
+  SOFTWARE_TITLE: Rectangle
+  INCLUDE_PRERELEASES: null
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: 'Rectangle[\d.]+\.dmg'
+      github_repo: rxhanson/Rectangle
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.dmg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/Rectangle.app'
+      requirement: identifier "com.knollsoft.Rectangle" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = XSYZ3E4B7D
+      strict_verification: true

--- a/Rectangle/Rectangle.pkg.recipe.yaml
+++ b/Rectangle/Rectangle.pkg.recipe.yaml
@@ -1,0 +1,15 @@
+Description: |
+  Wraps the downloaded Rectangle.app into an installer pkg.
+Identifier: com.github.smithjw.pkg.Rectangle
+ParentRecipe: com.github.smithjw.download.Rectangle
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Rectangle
+  SOFTWARE_TITLE: Rectangle
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/Rectangle.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/Rectangle/Rectangle.upload.jamf.recipe.yaml
+++ b/Rectangle/Rectangle.upload.jamf.recipe.yaml
@@ -1,0 +1,31 @@
+Description: |
+  Downloads the latest version of Rectangle, packages it, and uploads to Jamf Pro.
+Identifier: com.github.smithjw.jamf.upload.Rectangle
+ParentRecipe: com.github.smithjw.pkg.Rectangle
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Rectangle
+  SOFTWARE_TITLE: Rectangle
+  CATEGORY: Utilities
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Ricoh/Ricoh_CloudStream_Client.download.recipe.yaml
+++ b/Ricoh/Ricoh_CloudStream_Client.download.recipe.yaml
@@ -1,0 +1,38 @@
+Description: Downloads latest version of the Ricoh CloudStream Client
+Identifier: com.github.smithjw.download.Ricoh_CloudStream_Client
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Ricoh CloudStream Client
+  SOFTWARE_TITLE: Ricoh_CloudStream_Client
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+  DOWNLOAD_MISSING_FILE: null
+  DOWNLOAD_URL: https://cdn.everyoneprint.com/ricoh-cloudstream-client-2025.11.27.1-setup.pkg
+
+Process:
+  # - Processor: URLTextSearcher
+  #   Arguments:
+  #     re_pattern: <h2.*?id="(?P<version>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+))".*?><span.*?></span>(?P=version)
+  #     url: https://manual.na.ps.cloudstream.ricoh.com/docs/latest
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      fetch_filename: true
+      url: '%DOWNLOAD_URL%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Y Soft Corporation, a.s. (3CPED8WGS9)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/Ricoh/Ricoh_CloudStream_Client.pkg.recipe.yaml
+++ b/Ricoh/Ricoh_CloudStream_Client.pkg.recipe.yaml
@@ -1,0 +1,33 @@
+Description: Downloads latest Ricoh CloudStream Client disk images and creates a universal pkg that installs the correct architecture.
+Identifier: com.github.smithjw.pkg.Ricoh_CloudStream_Client
+ParentRecipe: com.github.smithjw.download.Ricoh_CloudStream_Client
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Ricoh CloudStream Client
+  SOFTWARE_TITLE: Ricoh_CloudStream_Client
+
+Process:
+  - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
+    Arguments:
+      archive_path: '%pathname%'
+      file_to_extract: Distribution
+
+  - Processor: com.github.mlbz521.SharedProcessors/XPathParser
+    Arguments:
+      attribute_one: CFBundleShortVersionString
+      return_variable_attribute_one: version
+      xml_file: '%extracted_file%'
+      xpath: .//pkg-ref//bundle[@id='com.ricoh.cloudstreamclient'][@CFBundleShortVersionString]
+
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'
+        - '%RECIPE_CACHE_DIR%/extractedfile'

--- a/Ricoh/Ricoh_CloudStream_Client.upload.jamf.recipe.yaml
+++ b/Ricoh/Ricoh_CloudStream_Client.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Ricoh_CloudStream_Client
+ParentRecipe: com.github.smithjw.pkg.Ricoh_CloudStream_Client
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Ricoh CloudStream Client
+  SOFTWARE_TITLE: Ricoh_CloudStream_Client
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Snowflake/snowflakeODBC.download.recipe.yaml
+++ b/Snowflake/snowflakeODBC.download.recipe.yaml
@@ -1,0 +1,39 @@
+Description: Downloads the latest version of Snowflake ODBC and creates an installer package.
+Identifier: com.github.smithjw.download.snowflakeODBC
+MinimumVersion: '2.9'
+
+Input:
+  NAME: snowflakeODBC
+  SOFTWARE_TITLE: '%NAME%'
+  BASE_URL: https://sfc-repo.snowflakecomputing.com/odbc/macuniversal/latest
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: snowflake_odbc_mac_64universal-([0-9]+\.[0-9]+\.[0-9]+).dmg
+      result_output_var_name: version
+      url: '%BASE_URL%/index.html'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      fetch_filename: true
+      url: '%BASE_URL%/snowflake_odbc_mac_64universal-%version%.dmg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%pathname%/*.pkg'
+      expected_authority_names:
+        - 'Developer ID Installer: Snowflake Computing INC. (W4NT6CRQ7U)'
+        - Developer ID Certification Authority
+        - Apple Root CA

--- a/Snowflake/snowflakeODBC.pkg.recipe.yaml
+++ b/Snowflake/snowflakeODBC.pkg.recipe.yaml
@@ -1,0 +1,14 @@
+Description: Downloads the latest version of Snowflake ODBC and creates an installer package.
+Identifier: com.github.smithjw.pkg.snowflakeODBC
+ParentRecipe: com.github.smithjw.download.snowflakeODBC
+MinimumVersion: '2.9'
+
+Input:
+  NAME: snowflakeODBC
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: PkgCopier
+    Arguments:
+      source_pkg: '%pathname%/*.pkg'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/Snowflake/snowflakeODBC.upload.jamf.recipe.yaml
+++ b/Snowflake/snowflakeODBC.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.snowflakeODBC
+ParentRecipe: com.github.smithjw.pkg.snowflakeODBC
+MinimumVersion: '2.9'
+
+Input:
+  NAME: snowflakeODBC
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Sourcetree/Sourcetree.download.recipe.yaml
+++ b/Sourcetree/Sourcetree.download.recipe.yaml
@@ -1,0 +1,57 @@
+Description: |
+  Downloads Sourcetree and produces a verified artefact for downstream packaging.
+
+  Run as part of the full download → pkg → upload chain. The `URLDownloaderPython`
+  processor caches by ETag/Last-Modified/Content-Length and the
+  `StopProcessingIf download_changed == False` predicate short-circuits the chain
+  on no-op re-runs. Pointing the upload recipe at a pre-built pkg would defeat
+  this cache and re-upload on every CI run.
+
+  Atlassian retired the static `Sourcetree.dmg` redirector — it now returns 403. The
+  current pattern is to scrape the Sourcetree download page for the latest versioned
+  download URL of the form
+  `https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_<x.y.z>_<build>.zip`
+  and pull from there.
+
+  Sourcetree ships as a universal binary, so a single download is sufficient.
+Identifier: com.github.smithjw.download.Sourcetree
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Sourcetree
+  SOFTWARE_TITLE: Sourcetree
+  DOWNLOAD_PAGE: https://www.sourcetreeapp.com/
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      url: '%DOWNLOAD_PAGE%'
+      re_pattern: 'https://product-downloads\.atlassian\.com/software/sourcetree/ga/Sourcetree_(?P<version>\d+\.\d+\.\d+)_(?P<build>\d+)\.zip'
+      result_output_var_name: download_url
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.zip'
+      url: 'https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_%version%_%build%.zip'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%pathname%'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      purge_destination: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/unpack/Sourcetree.app'
+      requirement: identifier "com.torusknot.SourceTreeNotMAS" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UPXU4CQZ5P
+      strict_verification: true

--- a/Sourcetree/Sourcetree.pkg.recipe.yaml
+++ b/Sourcetree/Sourcetree.pkg.recipe.yaml
@@ -1,0 +1,21 @@
+Description: |
+  Wraps the unpacked Sourcetree.app into an installer pkg.
+Identifier: com.github.smithjw.pkg.Sourcetree
+ParentRecipe: com.github.smithjw.download.Sourcetree
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Sourcetree
+  SOFTWARE_TITLE: Sourcetree
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/unpack/Sourcetree.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/unpack'

--- a/Sourcetree/Sourcetree.upload.jamf.recipe.yaml
+++ b/Sourcetree/Sourcetree.upload.jamf.recipe.yaml
@@ -1,0 +1,31 @@
+Description: |
+  Downloads the latest version of Sourcetree, packages it, and uploads to Jamf Pro.
+Identifier: com.github.smithjw.jamf.upload.Sourcetree
+ParentRecipe: com.github.smithjw.pkg.Sourcetree
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Sourcetree
+  SOFTWARE_TITLE: Sourcetree
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Sublime_Text/Sublime_Text.download.recipe.yaml
+++ b/Sublime_Text/Sublime_Text.download.recipe.yaml
@@ -1,0 +1,55 @@
+Description: |
+  Downloads Sublime Text and produces a verified artefact for downstream packaging.
+
+  Run as part of the full download → pkg → upload chain. The `URLDownloaderPython`
+  processor caches by ETag/Last-Modified/Content-Length and the
+  `StopProcessingIf download_changed == False` predicate short-circuits the chain
+  on no-op re-runs. Pointing the upload recipe at a pre-built pkg would defeat
+  this cache and re-upload on every CI run.
+
+  Sublime Text uses build numbers in its filename pattern
+  (`sublime_text_build_<build>_mac.zip`). We scrape the download page to find the
+  current build, then construct the URL.
+
+  Sublime Text 4 ships as a universal binary, so a single download is sufficient.
+Identifier: com.github.smithjw.download.Sublime_Text
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Sublime Text
+  SOFTWARE_TITLE: Sublime_Text
+  DOWNLOAD_PAGE: https://www.sublimetext.com/download
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      url: '%DOWNLOAD_PAGE%'
+      re_pattern: 'Build (?P<version>\d+)'
+      result_output_var_name: version
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-%version%.zip'
+      url: 'https://download.sublimetext.com/sublime_text_build_%version%_mac.zip'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%pathname%'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      purge_destination: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/unpack/Sublime Text.app'
+      requirement: identifier "com.sublimetext.4" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "Z6D26JE4Y4"
+      strict_verification: true

--- a/Sublime_Text/Sublime_Text.pkg.recipe.yaml
+++ b/Sublime_Text/Sublime_Text.pkg.recipe.yaml
@@ -1,0 +1,21 @@
+Description: |
+  Wraps the downloaded Sublime Text.app into an installer pkg.
+Identifier: com.github.smithjw.pkg.Sublime_Text
+ParentRecipe: com.github.smithjw.download.Sublime_Text
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Sublime Text
+  SOFTWARE_TITLE: Sublime_Text
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/unpack/Sublime Text.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/unpack'

--- a/Sublime_Text/Sublime_Text.upload.jamf.recipe.yaml
+++ b/Sublime_Text/Sublime_Text.upload.jamf.recipe.yaml
@@ -1,0 +1,31 @@
+Description: |
+  Downloads the latest version of Sublime Text, packages it, and uploads to Jamf Pro.
+Identifier: com.github.smithjw.jamf.upload.Sublime_Text
+ParentRecipe: com.github.smithjw.pkg.Sublime_Text
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Sublime Text
+  SOFTWARE_TITLE: Sublime_Text
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Suitcase_Fusion/Suitcase_Fusion.download.recipe.yaml
+++ b/Suitcase_Fusion/Suitcase_Fusion.download.recipe.yaml
@@ -1,0 +1,41 @@
+Description: Downloads the current release version of Suitcase Fusion
+Identifier: com.github.smithjw.download.Suitcase_Fusion
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Suitcase Fusion
+  SOFTWARE_TITLE: Suitcase_Fusion
+  SPARKLE_FEED_URL: https://sparkle.extensis.com/u/ST/EN/suitcase21en.xml
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: SparkleUpdateInfoProvider
+    Arguments:
+      appcast_url: '%SPARKLE_FEED_URL%'
+
+  - Processor: FindAndReplace
+    Arguments:
+      input_string: '%url%'
+      find: 'http://'
+      replace: 'https://'
+      result_output_var_name: url
+      appcast_url: '%SPARKLE_FEED_URL%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.dmg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%pathname%/*.app'
+      requirement: identifier "com.extensis.SuitcaseFusion" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = J6MMHGD9D6

--- a/Suitcase_Fusion/Suitcase_Fusion.pkg.recipe.yaml
+++ b/Suitcase_Fusion/Suitcase_Fusion.pkg.recipe.yaml
@@ -1,0 +1,18 @@
+Description: Downloads the latest version of Suitcase Fusion 21 and makes a pkg of it
+Identifier: com.github.smithjw.pkg.Suitcase_Fusion
+ParentRecipe: com.github.smithjw.download.Suitcase_Fusion
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Suitcase Fusion
+  SOFTWARE_TITLE: Suitcase_Fusion
+
+Process:
+  - Processor: AppDmgVersioner
+    Arguments:
+      dmg_path: '%pathname%'
+
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%pathname%/*.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/Suitcase_Fusion/Suitcase_Fusion.upload.jamf.recipe.yaml
+++ b/Suitcase_Fusion/Suitcase_Fusion.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Suitcase_Fusion
+ParentRecipe: com.github.smithjw.pkg.Suitcase_Fusion
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Suitcase Fusion
+  SOFTWARE_TITLE: Suitcase_Fusion
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Suspicious_Package/Suspicious_Package.download.recipe.yaml
+++ b/Suspicious_Package/Suspicious_Package.download.recipe.yaml
@@ -1,0 +1,45 @@
+Description: |
+  Downloads Suspicious Package and produces a verified artefact for downstream packaging.
+
+  Run as part of the full download → pkg → upload chain. The `URLDownloaderPython`
+  processor caches by ETag/Last-Modified/Content-Length and the
+  `StopProcessingIf download_changed == False` predicate short-circuits the chain
+  on no-op re-runs. Pointing the upload recipe at a pre-built pkg would defeat
+  this cache and re-upload on every CI run.
+
+  Downloads the most recent signed release dmg of Suspicious Package from the vendor's
+  static URL.
+Identifier: com.github.smithjw.download.Suspicious_Package
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Suspicious Package
+  SOFTWARE_TITLE: Suspicious_Package
+  DOWNLOAD_URL: https://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.dmg'
+      url: '%DOWNLOAD_URL%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/Suspicious Package.app'
+      requirement: identifier "com.mothersruin.SuspiciousPackageApp" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "936EB786NH"
+      strict_verification: true
+
+  - Processor: Versioner
+    Arguments:
+      input_plist_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/Suspicious Package.app/Contents/Info.plist'
+      plist_version_key: CFBundleShortVersionString

--- a/Suspicious_Package/Suspicious_Package.pkg.recipe.yaml
+++ b/Suspicious_Package/Suspicious_Package.pkg.recipe.yaml
@@ -1,0 +1,15 @@
+Description: |
+  Wraps the downloaded Suspicious Package.app into an installer pkg.
+Identifier: com.github.smithjw.pkg.Suspicious_Package
+ParentRecipe: com.github.smithjw.download.Suspicious_Package
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Suspicious Package
+  SOFTWARE_TITLE: Suspicious_Package
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/Suspicious Package.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/Suspicious_Package/Suspicious_Package.upload.jamf.recipe.yaml
+++ b/Suspicious_Package/Suspicious_Package.upload.jamf.recipe.yaml
@@ -1,0 +1,31 @@
+Description: |
+  Downloads the latest version of Suspicious Package, packages it, and uploads to Jamf Pro.
+Identifier: com.github.smithjw.jamf.upload.Suspicious_Package
+ParentRecipe: com.github.smithjw.pkg.Suspicious_Package
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Suspicious Package
+  SOFTWARE_TITLE: Suspicious_Package
+  CATEGORY: Utilities
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Tableau/Tableau_Desktop.download.recipe.yaml
+++ b/Tableau/Tableau_Desktop.download.recipe.yaml
@@ -1,0 +1,56 @@
+Description: Downloads latest Tableau Desktop disk images for both Intel and ARM architectures.
+Identifier: com.github.smithjw.download.Tableau_Desktop
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Tableau Desktop
+  SOFTWARE_TITLE: Tableau_Desktop
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  # Example URLs once you have a free Tableau account:
+  #   - https://downloads.tableau.com/esdalt/2025.2.3/TableauDesktop-2025-2-3.dmg
+  #   - https://downloads.tableau.com/esdalt/2025.2.3/TableauDesktop-2025-2-3-arm64.dmg
+
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: <a href="(\/.*?)+\/(?P<version>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+))#.*class="cta">
+      url: https://www.tableau.com/support/releases
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-x86_64.dmg'
+      url: https://downloads.tableau.com/esdalt/%version%/TableauDesktop-%major%-%minor%-%patch%.dmg
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-arm64.dmg'
+      url: https://downloads.tableau.com/esdalt/%version%/TableauDesktop-%major%-%minor%-%patch%-arm64.dmg
+
+  - Processor: EndOfCheckPhase
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Tableau Software, LLC (QJ4XPRK37C)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg/Tableau Desktop.pkg'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Tableau Software, LLC (QJ4XPRK37C)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Tableau Desktop.pkg'

--- a/Tableau/Tableau_Desktop.pkg.recipe.yaml
+++ b/Tableau/Tableau_Desktop.pkg.recipe.yaml
@@ -1,0 +1,69 @@
+Description: Downloads latest Tableau Desktop disk images and creates a universal pkg that installs the correct architecture.
+Identifier: com.github.smithjw.pkg.Tableau_Desktop
+ParentRecipe: com.github.smithjw.download.Tableau_Desktop
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Tableau Desktop
+  SOFTWARE_TITLE: Tableau_Desktop
+
+Process:
+  - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
+    Arguments:
+      archive_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Tableau Desktop.pkg'
+      file_to_extract: Distribution
+
+  - Processor: com.github.mlbz521.SharedProcessors/XPathParser
+    Arguments:
+      attribute_one: CFBundleShortVersionString
+      return_variable_attribute_one: version
+      xml_file: '%extracted_file%'
+      xpath: .//pkg-ref//bundle[@id='com.tableausoftware.tableaudesktop'][@CFBundleShortVersionString]
+
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Tableau Desktop.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-arm64.pkg'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg/Tableau Desktop.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-x86_64.pkg'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/sbin/installer -pkg %SOFTWARE_TITLE%-arm64.pkg -target /
+        else
+          /usr/sbin/installer -pkg %SOFTWARE_TITLE%-x86_64.pkg -target /
+        fi
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: com.tableausoftware.tableaudesktop
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'
+        - '%RECIPE_CACHE_DIR%/extractedfile'

--- a/Tableau/Tableau_Desktop.upload.jamf.recipe.yaml
+++ b/Tableau/Tableau_Desktop.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Tableau Desktop empowers users to create, analyze, and visualize data with interactive dashboards and reports, making data-driven decision-making easy.
+Identifier: com.github.smithjw.jamf.upload.Tableau_Desktop
+ParentRecipe: com.github.smithjw.pkg.Tableau_Desktop
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Tableau Desktop
+  SOFTWARE_TITLE: Tableau_Desktop
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Tableau/Tableau_Prep_Builder.download.recipe.yaml
+++ b/Tableau/Tableau_Prep_Builder.download.recipe.yaml
@@ -1,0 +1,31 @@
+Description: Downloads latest Tableau Prep disk image.
+Identifier: com.github.smithjw.download.Tableau_Prep_Builder
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Tableau Prep Builder
+  SOFTWARE_TITLE: Tableau_Prep_Builder
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.dmg'
+      url: https://www.tableau.com/downloads/prep/mac
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Tableau Software, LLC (QJ4XPRK37C)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%/Tableau Prep Builder.pkg'

--- a/Tableau/Tableau_Prep_Builder.pkg.recipe.yaml
+++ b/Tableau/Tableau_Prep_Builder.pkg.recipe.yaml
@@ -1,0 +1,32 @@
+Description: Downloads latest Tableau Prep disk image and makes a pkg.
+Identifier: com.github.smithjw.pkg.Tableau_Prep_Builder
+ParentRecipe: com.github.smithjw.download.Tableau_Prep_Builder
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Tableau Prep Builder
+  SOFTWARE_TITLE: Tableau_Prep_Builder
+
+Process:
+  - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
+    Arguments:
+      archive_path: '%pathname%/Tableau Prep Builder.pkg'
+      file_to_extract: Distribution
+
+  - Processor: com.github.mlbz521.SharedProcessors/XPathParser
+    Arguments:
+      attribute_one: CFBundleShortVersionString
+      return_variable_attribute_one: version
+      xml_file: '%extracted_file%'
+      xpath: .//pkg-ref//bundle[@id='com.tableausoftware.tableauprep'][@CFBundleShortVersionString]
+
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%/Tableau Prep Builder.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/extractedfile'

--- a/Tableau/Tableau_Prep_Builder.upload.jamf.recipe.yaml
+++ b/Tableau/Tableau_Prep_Builder.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Downloads the latest version Tableau Prep Builder, packages it, then uploads it to Jamf.
+Identifier: com.github.smithjw.jamf.upload.Tableau_Prep_Builder
+ParentRecipe: com.github.smithjw.pkg.Tableau_Prep_Builder
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Tableau Prep Builder
+  SOFTWARE_TITLE: Tableau_Prep_Builder
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Talon_Voice/Talon_Voice.download.recipe.yaml
+++ b/Talon_Voice/Talon_Voice.download.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Downloads the latest version of Talon Voice for macOS.
+Identifier: com.github.smithjw.download.Talon_Voice
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Talon Voice
+  SOFTWARE_TITLE: Talon_Voice
+  DOWNLOAD_URL: https://talonvoice.com/dl/latest/talon-mac.dmg
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.dmg'
+      url: '%DOWNLOAD_URL%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%pathname%/Talon.app'
+      requirement: identifier "com.talonvoice.Talon" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = D7SCFBXQXZ

--- a/Talon_Voice/Talon_Voice.pkg.recipe.yaml
+++ b/Talon_Voice/Talon_Voice.pkg.recipe.yaml
@@ -1,0 +1,18 @@
+Description: Downloads the latest version of Talon Voice and creates an installer package.
+Identifier: com.github.smithjw.pkg.Talon_Voice
+ParentRecipe: com.github.smithjw.download.Talon_Voice
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Talon Voice
+  SOFTWARE_TITLE: Talon_Voice
+
+Process:
+  - Processor: AppDmgVersioner
+    Arguments:
+      dmg_path: '%pathname%'
+
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%pathname%/Talon.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/Talon_Voice/Talon_Voice.upload.jamf.recipe.yaml
+++ b/Talon_Voice/Talon_Voice.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Downloads the latest version of Talon Voice, creates an installer package, and uploads it to Jamf Pro.
+Identifier: com.github.smithjw.jamf.upload.Talon_Voice
+ParentRecipe: com.github.smithjw.pkg.Talon_Voice
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Talon Voice
+  SOFTWARE_TITLE: Talon_Voice
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Teradata/TeradataProductURLFinder.py
+++ b/Teradata/TeradataProductURLFinder.py
@@ -1,0 +1,545 @@
+#!/usr/local/autopkg/python
+#
+# Copyright 2025 James Smith
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""See docstring for TeradataProductURLFinder class"""
+
+from __future__ import absolute_import
+
+import json
+import os
+import re
+import tempfile
+from html.parser import HTMLParser
+from urllib.parse import urlparse
+
+from autopkglib import ProcessorError, URLGetter
+
+__all__ = ["TeradataProductURLFinder"]
+
+
+class TerradataVersionInfo(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.versions = []
+        self.current_data = None
+
+    def handle_starttag(self, tag, attrs):
+        # Check for div tags with class "version" or "date"
+        if tag == "div":
+            for attr, value in attrs:
+                if attr == "class" and value == "version":
+                    self.current_data = "version"
+                elif attr == "class" and value == "date":
+                    self.current_data = "date"
+
+    def handle_data(self, data):
+        # Capture the version or date data
+        if self.current_data == "version":
+            self.versions.append({"version": data.strip()})
+            self.current_data = None
+        elif self.current_data == "date":
+            if self.versions:
+                self.versions[-1]["date"] = data.strip()
+            self.current_data = None
+
+
+class FilteredDownloadLinkExtractor(HTMLParser):
+    def __init__(self, app_info, arch):
+        super().__init__()
+        self.app_info = app_info
+        self.arch = arch
+        self.filtered_link = None
+        self.current_link = None
+        self.current_text = ""
+        self.capturing_text = False
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "a":
+            self.current_link = dict(attrs).get("href")
+        elif tag == "span":
+            self.capturing_text = True
+            self.current_text = ""
+
+    def handle_data(self, data):
+        if self.capturing_text:
+            self.current_text += (
+                data.strip() if self.app_info.get("use_vantage_pattern") else data
+            )
+
+    def handle_endtag(self, tag):
+        if tag == "span":
+            self.capturing_text = False
+        elif tag == "a" and self.current_link and self.current_text:
+            if self._matches_criteria():
+                self.filtered_link = self.current_link
+            self._reset_state()
+
+    def _matches_criteria(self):
+        """Check if current link matches the filtering criteria."""
+        # Search pattern matching (for TTU)
+        if self.app_info.get("search_pattern"):
+            return re.search(self.app_info["search_pattern"], self.current_text)
+
+        # Vantage pattern matching
+        if self.app_info.get("use_vantage_pattern"):
+            text_lower = self.current_text.lower().replace(" ", "")
+            if self.arch == "aarch64":
+                return "macosm1pkg" in text_lower
+            elif self.arch == "x86":
+                return "macosintelpkg" in text_lower
+
+        # Original Teradata pattern matching
+        if "__" in self.current_text and "mac_" in self.current_text:
+            product_name = self.current_text.split("__")[0]
+            arch_part = self.current_text.split("mac_")[-1]
+            return self.app_info.get("name") == product_name and self.arch in arch_part
+
+        return False
+
+    def _reset_state(self):
+        """Reset parsing state."""
+        self.current_link = None
+        self.current_text = ""
+
+
+class TeradataProductURLFinder(URLGetter):
+    """Downloads Teradata Studio from Teradata's website."""
+
+    description = __doc__
+
+    # Teradata's site blocks curl's default UA; use a browser UA for all requests.
+    USER_AGENT = (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7_5) "
+        "AppleWebKit/605.1.15 (KHTML, like Gecko) "
+        "Version/26.0 Safari/605.1.15"
+    )
+    input_variables = {
+        "teradata_username": {
+            "required": True,
+            "description": ("Username Teradata Account"),
+        },
+        "teradata_password": {
+            "required": True,
+            "description": ("Password Teradata Account"),
+        },
+        "app": {
+            "required": True,
+            "description": (
+                "App identifier (teradata_studio, teradata_studio_express, teradata_tools_utilities, teradata_vantage_editor)"
+            ),
+        },
+        "architecture": {
+            "required": False,
+            "description": ("Architecture (aarch64 or x86)"),
+        },
+    }
+    output_variables = {
+        "url": {
+            "description": "URL to the requested Teradata product",
+        },
+        "version": {
+            "description": "Version",
+        },
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cookie_file = None
+        self.app_info = {
+            "teradata_studio": {
+                "nid": 183396,
+                "os": 10872,
+                "url": "https://downloads.teradata.com/download/tools/teradata-studio",
+                "name": "TeradataStudio",
+                "valid_archs": ["aarch64", "x86"],
+            },
+            "teradata_studio_express": {
+                "nid": 7557,
+                "os": 10872,
+                "url": "https://downloads.teradata.com/download/tools/teradata-studio-express",
+                "name": "TeradataStudioExpress",
+                "valid_archs": ["aarch64", "x86"],
+            },
+            "teradata_tools_utilities": {
+                "nid": 201214,
+                "os": 1541,
+                "url": "https://downloads.teradata.com/download/tools/teradata-tools-and-utilities-mac-osx-installation-package",
+                "name": "TTU",
+                "search_pattern": "^TTU\s\d+\.\d+\.\d+\.\d+\smacOS\sBase$",
+            },
+            "teradata_vantage_editor": {
+                "nid": 202573,
+                "os": 10872,
+                "url": "https://downloads.teradata.com/download/tools/vantage-editor-desktop",
+                "name": "Vantage Editor",
+                "valid_archs": ["aarch64", "x86"],
+                "use_vantage_pattern": True,
+            },
+        }
+
+    def _get_cookie_file(self):
+        """Get or create a temporary cookie file."""
+        if not self.cookie_file:
+            self.cookie_file = tempfile.NamedTemporaryFile(
+                delete=False, suffix=".txt"
+            ).name
+        return self.cookie_file
+
+    def _cleanup_cookie_file(self):
+        """Clean up the temporary cookie file."""
+        if self.cookie_file and os.path.exists(self.cookie_file):
+            os.unlink(self.cookie_file)
+            self.cookie_file = None
+
+    def _add_proxy_from_env(self, curl_cmd) -> None:
+        """Append --proxy / --proxy-user to curl_cmd from proxy environment variables.
+
+        All Teradata endpoints are HTTPS, so only HTTPS-specific and generic proxy
+        vars are consulted — HTTP_PROXY/http_proxy are intentionally excluded to
+        avoid the CGI header-injection vulnerability documented in curl's own source.
+
+        Priority (mirrors curl for HTTPS targets):
+          HTTPS_PROXY → https_proxy → ALL_PROXY → all_proxy
+
+        If a proxy URL contains embedded credentials (http://user:pass@host:port)
+        they are split out into a separate --proxy-user flag. The URL passed to
+        --proxy is rebuilt without credentials so it is safe to log.
+
+        Respects NO_PROXY/no_proxy: if the target host matches the bypass list the
+        method is a no-op. Target hostname is resolved from the Teradata base URL
+        since curl_cmd does not yet contain the destination at call time.
+
+        If --proxy is already present in curl_cmd (set via curl_opts) this method
+        is a no-op — explicit recipe/prefs configuration takes precedence.
+        """
+        # Explicit curl_opts proxy wins; do not override it.
+        if "--proxy" in curl_cmd:
+            return
+
+        proxy_url = None
+        for var in ("HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"):
+            proxy_url = os.environ.get(var)
+            if proxy_url:
+                break
+
+        if not proxy_url:
+            return
+
+        # Respect NO_PROXY / no_proxy for the Teradata base domain.
+        from urllib.request import proxy_bypass
+
+        if proxy_bypass("downloads.teradata.com"):
+            return
+
+        parsed = urlparse(proxy_url)
+
+        # Rebuild netloc without credentials; handle IPv6 literal hostnames
+        # (urlparse strips brackets from hostname, so we must restore them).
+        host = parsed.hostname or ""
+        if ":" in host:
+            host = f"[{host}]"
+        netloc = f"{host}:{parsed.port}" if parsed.port else host
+        clean_url = parsed._replace(netloc=netloc).geturl()
+
+        curl_cmd.extend(["--proxy", clean_url])
+
+        # Emit --proxy-user separately only when credentials are present.
+        # The value is intentionally kept out of clean_url so that the URL
+        # logged by download_with_curl does not contain the password.
+        if parsed.username:
+            curl_cmd.extend(
+                ["--proxy-user", f"{parsed.username}:{parsed.password or ''}"]
+            )
+
+    def download_with_curl(self, curl_cmd, text=True) -> str:
+        """Override to redact --proxy-user value from verbose curl command log."""
+        safe_cmd = []
+        skip_next = False
+        for arg in curl_cmd:
+            if skip_next:
+                safe_cmd.append("<redacted>")
+                skip_next = False
+            else:
+                safe_cmd.append(arg)
+                if arg in ("--proxy-user", "-U"):
+                    skip_next = True
+        self.output(f"Curl command: {safe_cmd}", verbose_level=4)
+        proc_stdout, proc_stderr, retcode = self.execute_curl(curl_cmd, text)
+        if retcode:
+            curl_err = self.parse_curl_error(proc_stderr)
+            raise ProcessorError(f"curl failure: {curl_err} (exit code {retcode})")
+        return proc_stdout
+
+    def _build_post_curl_cmd(
+        self, url, data, use_cookies=True, save_cookies=False, include_headers=False
+    ):
+        """Build a POST curl command with common options."""
+        curl_cmd = self.prepare_curl_cmd()
+        self._add_proxy_from_env(curl_cmd)
+        self.add_curl_common_opts(curl_cmd)
+        curl_cmd.extend(["--user-agent", self.USER_AGENT])
+        curl_cmd.extend(["-X", "POST"])
+        curl_cmd.extend(["-H", "Content-Type: application/x-www-form-urlencoded"])
+
+        if save_cookies:
+            curl_cmd.extend(["-c", self._get_cookie_file()])
+        elif use_cookies:
+            curl_cmd.extend(["-b", self._get_cookie_file()])
+
+        if include_headers:
+            curl_cmd.extend(["-D", "-"])
+
+        for key, value in data.items():
+            curl_cmd.extend(["-d", f"{key}={value}"])
+        curl_cmd.append(url)
+        return curl_cmd
+
+    def _build_get_curl_cmd(self, url, use_cookies=True):
+        """Build a GET curl command with common options."""
+        curl_cmd = self.prepare_curl_cmd()
+        self._add_proxy_from_env(curl_cmd)
+        self.add_curl_common_opts(curl_cmd)
+        curl_cmd.extend(["--user-agent", self.USER_AGENT])
+        if use_cookies:
+            curl_cmd.extend(["-b", self._get_cookie_file()])
+        curl_cmd.append(url)
+        return curl_cmd
+
+    def download(self, url, headers=None, text=False) -> str:
+        """Override URLGetter.download to ensure proxy env vars are applied."""
+        curl_cmd = self.prepare_curl_cmd()
+        self._add_proxy_from_env(curl_cmd)
+        self.add_curl_common_opts(curl_cmd)
+        curl_cmd.extend(["--user-agent", self.USER_AGENT])
+        self.add_curl_headers(curl_cmd, headers)
+        curl_cmd.append(url)
+        return self.download_with_curl(curl_cmd, text)
+
+    def _validate_cloudfront_url(self, url, app):
+        """Validate CloudFront URL for Vantage apps."""
+        if self.app_info[app].get("use_vantage_pattern", False):
+            if ".cloudfront.net" not in url:
+                raise ProcessorError("Unexpected download URL. Not a CloudFront link.")
+
+    def get_product_version(self, app):
+        """Returns the product version using multiple detection strategies."""
+        url = self.app_info[app]["url"]
+        downloads_page = self.download(url, text=True)
+
+        # Strategy 1: Single version div (Vantage pattern)
+        match = re.search(r'<div id="single_version">([^<]+)</div>', downloads_page)
+        if match:
+            version = match.group(1).strip()
+            self.output(f"Found version (single_version): {version}")
+            return version
+
+        # Strategy 2: Select option pattern (Vantage fallback)
+        match = re.search(
+            r'<select[^>]*id="edit-version"[^>]*>.*?<option value="([^"]+)"',
+            downloads_page,
+            re.DOTALL,
+        )
+        if match:
+            version = match.group(1).strip()
+            self.output(f"Found version (select_option): {version}")
+            return version
+
+        # Strategy 3: HTML parser for version/date divs (Original Teradata)
+        parser = TerradataVersionInfo()
+        parser.feed(downloads_page)
+        if parser.versions:
+            version = parser.versions[0]["version"]
+            self.output(f"Found version (html_parser): {version}")
+            return version
+
+        # Strategy 4: Generic version pattern matching
+        version_patterns = [
+            r'version["\s]*:?\s*["\']([^"\']+)["\']',
+            r'<span[^>]*class="version"[^>]*>([^<]+)</span>',
+            r'data-version="([^"]+)"',
+        ]
+
+        for pattern in version_patterns:
+            match = re.search(pattern, downloads_page, re.IGNORECASE)
+            if match:
+                version = match.group(1).strip()
+                self.output(f"Found version (pattern_match): {version}")
+                return version
+
+        # Default fallback
+        default_version = (
+            "1.0" if self.app_info[app].get("use_vantage_pattern") else None
+        )
+        self.output(f"Version not found, using default: {default_version}")
+        return default_version
+
+    def get_download_url(self, username, password, app, architecture):
+        try:
+            # Step 1: Login
+            login_url = "https://downloads.teradata.com/user/login?destination="
+            login_data = {
+                "name": username,
+                "pass": password,
+                "form_id": "user_login_form",
+            }
+            curl_cmd = self._build_post_curl_cmd(
+                login_url, login_data, use_cookies=False, save_cookies=True
+            )
+            self.download_with_curl(curl_cmd, text=True)
+
+            # Step 2: Get downloads packages filter
+            filter_data = {
+                "os": self.app_info[app]["os"],
+                "version": self.env["version"],
+                "nid": self.app_info[app]["nid"],
+                "check_full_user_req": 0,
+                "check_user_details": "false",
+            }
+            curl_cmd = self._build_post_curl_cmd(
+                "https://downloads.teradata.com/downloads-packages/filter", filter_data
+            )
+            response_content = self.download_with_curl(curl_cmd, text=True)
+            download_data = json.loads(response_content)
+
+            # Step 3: Parse download links
+            parser = FilteredDownloadLinkExtractor(self.app_info[app], architecture)
+            parser.feed(download_data[0]["downloads_html"])
+            product_link = parser.filtered_link
+            if not product_link:
+                raise ProcessorError(
+                    f"Download link not found for {self.app_info[app]['name']}. Please check your credentials or the product name."
+                )
+
+            # Step 4: Prepare license acceptance data
+            if self.app_info[app].get("use_vantage_pattern", False):
+                # Vantage pattern: Get form tokens
+                curl_cmd = self._build_get_curl_cmd(product_link)
+                form_page_content = self.download_with_curl(curl_cmd, text=True)
+
+                form_build_id = re.search(
+                    r'name="form_build_id" value="([^"]+)"', form_page_content
+                )
+                form_token = re.search(
+                    r'name="form_token" value="([^"]+)"', form_page_content
+                )
+
+                if not form_build_id or not form_token:
+                    raise ProcessorError("Unable to parse license form tokens.")
+
+                final_data = {
+                    "op": "I Agree",
+                    "form_id": "license_popup_form",
+                    "form_build_id": form_build_id.group(1),
+                    "form_token": form_token.group(1),
+                }
+            else:
+                # Original Teradata pattern
+                final_data = {
+                    "downloadnid": self.app_info[app]["nid"],
+                    "form_id": "license_popup_form",
+                }
+
+            # Step 5: Submit license acceptance and get download URL
+            curl_cmd = self._build_post_curl_cmd(
+                product_link, final_data, use_cookies=False, include_headers=True
+            )
+
+            try:
+                response_with_headers = self.download_with_curl(curl_cmd, text=True)
+                # Parse headers from successful response
+                headers = self.parse_headers(response_with_headers.split("\r\n\r\n")[0])
+                download_url = headers.get("location") or headers.get("http_redirected")
+            except ProcessorError as e:
+                # Handle redirect responses (common for download URLs)
+                if any(code in str(e) for code in ["301", "302", "303"]):
+                    location_match = re.search(r"Location:\s*([^\r\n]+)", str(e))
+                    if location_match:
+                        download_url = location_match.group(1).strip()
+                    else:
+                        raise ProcessorError(
+                            "Could not extract download URL from redirect response"
+                        )
+                else:
+                    raise e
+
+            if not download_url:
+                raise ProcessorError(
+                    "Could not extract download URL from response headers"
+                )
+
+            # Validate URL for specific app types
+            self._validate_cloudfront_url(download_url, app)
+
+            self.output(f"Selected download link: {download_url}")
+            return download_url
+
+        finally:
+            # Always cleanup cookie file
+            self._cleanup_cookie_file()
+
+    def main(self):
+        # Validate required parameters
+        username = self.env.get("teradata_username")
+        password = self.env.get("teradata_password")
+        app = self.env.get("app")
+
+        if not username or not password:
+            raise ProcessorError("Username and password are required.")
+
+        if not app:
+            raise ProcessorError("App parameter is required.")
+
+        if app not in self.app_info:
+            raise ProcessorError(
+                f"Invalid app name: {app}. Valid options are: {list(self.app_info.keys())}"
+            )
+
+        # Handle architecture parameter
+        architecture = self.env.get("architecture")
+        valid_archs = self.app_info[app].get("valid_archs")
+
+        if valid_archs:
+            if not architecture:
+                # Default to first valid architecture if not specified
+                architecture = valid_archs[0]
+                self.output(
+                    f"Architecture not specified, defaulting to: {architecture}"
+                )
+            elif architecture not in valid_archs:
+                raise ProcessorError(
+                    f"Invalid architecture: {architecture}. Valid options are: {valid_archs}"
+                )
+
+        try:
+            # Get product version and download URL
+            self.env["version"] = self.get_product_version(app)
+            self.env["url"] = self.get_download_url(
+                username, password, app, architecture
+            )
+
+            self.output(
+                f"Successfully found download for {self.app_info[app].get('name', app)}"
+            )
+            self.output(f"Version: {self.env['version']}")
+            self.output(f"URL: {self.env['url']}")
+
+        except Exception as e:
+            self.output(f"Error processing {app}: {str(e)}")
+            raise ProcessorError(f"Failed to get download URL for {app}: {str(e)}")
+
+
+if __name__ == "__main__":
+    PROCESSOR = TeradataProductURLFinder()
+    PROCESSOR.execute_shell()

--- a/Teradata/Teradata_Studio.download.recipe.yaml
+++ b/Teradata/Teradata_Studio.download.recipe.yaml
@@ -1,0 +1,73 @@
+Description: Downloads the latest version of Teradata Studio
+Identifier: com.github.smithjw.download.Teradata_Studio
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Teradata Studio
+  SOFTWARE_TITLE: Teradata_Studio
+  PRODUCT: teradata_studio
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: TeradataProductURLFinder
+    Arguments:
+      app: '%PRODUCT%'
+      architecture: 'aarch64'
+      teradata_username: '%TERADATA_USERNAME%'
+      teradata_password: '%TERADATA_PASSWORD%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-arm64.zip'
+
+  - Processor: TeradataProductURLFinder
+    Arguments:
+      app: '%PRODUCT%'
+      architecture: 'x86'
+      teradata_username: '%TERADATA_USERNAME%'
+      teradata_password: '%TERADATA_PASSWORD%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-x86_64.zip'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.zip'
+      destination_path: '%RECIPE_CACHE_DIR%/extracted/arm64'
+      purge_destination: true
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.zip'
+      destination_path: '%RECIPE_CACHE_DIR%/extracted/x86_64'
+      purge_destination: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Teradata (Z6K9HW9JJ5)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/extracted/arm64/TeradataStudio.pkg'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Teradata (Z6K9HW9JJ5)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/extracted/x86_64/TeradataStudio.pkg'

--- a/Teradata/Teradata_Studio.pkg.recipe.yaml
+++ b/Teradata/Teradata_Studio.pkg.recipe.yaml
@@ -1,0 +1,83 @@
+Description: 'Downloads the latest version of Teradata Studio for macOS and packages it'
+Identifier: com.github.smithjw.pkg.Teradata_Studio
+ParentRecipe: com.github.smithjw.download.Teradata_Studio
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Teradata Studio
+  SOFTWARE_TITLE: Teradata_Studio
+
+Process:
+  - Processor: FlatPkgUnpacker
+    Arguments:
+      flat_pkg_path: '%RECIPE_CACHE_DIR%/extracted/arm64/TeradataStudio.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      skip_payload: false
+      purge_destination: true
+
+  - Processor: FileFinder
+    Arguments:
+      pattern: '%RECIPE_CACHE_DIR%/unpack/*.pkg'
+
+  - Processor: PkgPayloadUnpacker
+    Arguments:
+      pkg_payload_path: '%found_filename%/Payload'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack/payload'
+      purge_destination: true
+
+  - Processor: FileFinder
+    Arguments:
+      pattern: '%RECIPE_CACHE_DIR%/unpack/payload/*.app'
+
+  - Processor: Versioner
+    Arguments:
+      input_plist_path: '%found_filename%/Contents/Info.plist'
+
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/extracted/arm64/TeradataStudio.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/TeradataStudio-arm64.pkg'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/extracted/x86_64/TeradataStudio.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/TeradataStudio-x86_64.pkg'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/sbin/installer -pkg TeradataStudio-arm64.pkg -target /
+        else
+          /usr/sbin/installer -pkg TeradataStudio-x86_64.pkg -target /
+        fi
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: com.Teradata.Studio
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'
+        - '%RECIPE_CACHE_DIR%/unpack'
+        - '%RECIPE_CACHE_DIR%/extracted'

--- a/Teradata/Teradata_Studio.upload.jamf.recipe.yaml
+++ b/Teradata/Teradata_Studio.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Teradata_Studio
+ParentRecipe: com.github.smithjw.pkg.Teradata_Studio
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Teradata Studio
+  SOFTWARE_TITLE: Teradata_Studio
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Teradata/Teradata_Studio_Express.download.recipe.yaml
+++ b/Teradata/Teradata_Studio_Express.download.recipe.yaml
@@ -1,0 +1,73 @@
+Description: Downloads the latest version of Teradata Studio Express
+Identifier: com.github.smithjw.download.Teradata_Studio_Express
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Teradata Studio Express
+  SOFTWARE_TITLE: Teradata_Studio_Express
+  PRODUCT: teradata_studio_express
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: TeradataProductURLFinder
+    Arguments:
+      app: '%PRODUCT%'
+      architecture: 'aarch64'
+      teradata_username: '%TERADATA_USERNAME%'
+      teradata_password: '%TERADATA_PASSWORD%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-arm64.zip'
+
+  - Processor: TeradataProductURLFinder
+    Arguments:
+      app: '%PRODUCT%'
+      architecture: 'x86'
+      teradata_username: '%TERADATA_USERNAME%'
+      teradata_password: '%TERADATA_PASSWORD%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-x86_64.zip'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.zip'
+      destination_path: '%RECIPE_CACHE_DIR%/extracted/arm64'
+      purge_destination: true
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.zip'
+      destination_path: '%RECIPE_CACHE_DIR%/extracted/x86_64'
+      purge_destination: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Teradata (Z6K9HW9JJ5)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/extracted/arm64/TeradataStudioExpress.pkg'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Teradata (Z6K9HW9JJ5)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/extracted/x86_64/TeradataStudioExpress.pkg'

--- a/Teradata/Teradata_Studio_Express.pkg.recipe.yaml
+++ b/Teradata/Teradata_Studio_Express.pkg.recipe.yaml
@@ -1,0 +1,83 @@
+Description: 'Downloads the latest version of Teradata Studio Express for macOS and packages it'
+Identifier: com.github.smithjw.pkg.Teradata_Studio_Express
+ParentRecipe: com.github.smithjw.download.Teradata_Studio_Express
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Teradata Studio Express
+  SOFTWARE_TITLE: Teradata_Studio_Express
+
+Process:
+  - Processor: FlatPkgUnpacker
+    Arguments:
+      flat_pkg_path: '%RECIPE_CACHE_DIR%/extracted/arm64/TeradataStudioExpress.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      skip_payload: false
+      purge_destination: true
+
+  - Processor: FileFinder
+    Arguments:
+      pattern: '%RECIPE_CACHE_DIR%/unpack/*.pkg'
+
+  - Processor: PkgPayloadUnpacker
+    Arguments:
+      pkg_payload_path: '%found_filename%/Payload'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack/payload'
+      purge_destination: true
+
+  - Processor: FileFinder
+    Arguments:
+      pattern: '%RECIPE_CACHE_DIR%/unpack/payload/*.app'
+
+  - Processor: Versioner
+    Arguments:
+      input_plist_path: '%found_filename%/Contents/Info.plist'
+
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/extracted/arm64/TeradataStudioExpress.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/TeradataStudioExpress-arm64.pkg'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/extracted/x86_64/TeradataStudioExpress.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/TeradataStudioExpress-x86_64.pkg'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/sbin/installer -pkg TeradataStudioExpress-arm64.pkg -target /
+        else
+          /usr/sbin/installer -pkg TeradataStudioExpress-x86_64.pkg -target /
+        fi
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: com.Teradata.StudioExpress
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'
+        - '%RECIPE_CACHE_DIR%/unpack'
+        - '%RECIPE_CACHE_DIR%/extracted'

--- a/Teradata/Teradata_Studio_Express.upload.jamf.recipe.yaml
+++ b/Teradata/Teradata_Studio_Express.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Teradata_Studio_Express
+ParentRecipe: com.github.smithjw.pkg.Teradata_Studio_Express
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Teradata Studio Express
+  SOFTWARE_TITLE: Teradata_Studio_Express
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Teradata/Teradata_Tools_Utilities.download.recipe.yaml
+++ b/Teradata/Teradata_Tools_Utilities.download.recipe.yaml
@@ -1,0 +1,53 @@
+Description: Downloads the latest version of Teradata Tools and Utilities
+Identifier: com.github.smithjw.download.Teradata_Tools_Utilities
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Teradata Tools and Utilities
+  SOFTWARE_TITLE: Teradata_Tools_Utilities
+  PRODUCT: teradata_tools_utilities
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: TeradataProductURLFinder
+    Arguments:
+      app: '%PRODUCT%'
+      teradata_username: '%TERADATA_USERNAME%'
+      teradata_password: '%TERADATA_PASSWORD%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.tar.gz'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%pathname%'
+      destination_path: '%RECIPE_CACHE_DIR%/extracted'
+      purge_destination: true
+
+  - Processor: FileFinder
+    Arguments:
+      pattern: '%RECIPE_CACHE_DIR%/extracted/TeradataToolsAndUtilitiesBase/*.pkg'
+
+  - Processor: FileMover
+    Arguments:
+      source: '%found_filename%'
+      target: '%RECIPE_CACHE_DIR%/extracted/%SOFTWARE_TITLE%.pkg'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Teradata (Z6K9HW9JJ5)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/extracted/%SOFTWARE_TITLE%.pkg'

--- a/Teradata/Teradata_Tools_Utilities.pkg.recipe.yaml
+++ b/Teradata/Teradata_Tools_Utilities.pkg.recipe.yaml
@@ -1,0 +1,21 @@
+Description: 'Downloads the latest version of Teradata Tools and Utilities for macOS and packages it'
+Identifier: com.github.smithjw.pkg.Teradata_Tools_Utilities
+ParentRecipe: com.github.smithjw.download.Teradata_Tools_Utilities
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Teradata Tools and Utilities
+  SOFTWARE_TITLE: Teradata_Tools_Utilities
+
+Process:
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%RECIPE_CACHE_DIR%/extracted/%SOFTWARE_TITLE%.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'
+        - '%RECIPE_CACHE_DIR%/extracted'

--- a/Teradata/Teradata_Tools_Utilities.upload.jamf.recipe.yaml
+++ b/Teradata/Teradata_Tools_Utilities.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Teradata_Tools_Utilities
+ParentRecipe: com.github.smithjw.pkg.Teradata_Tools_Utilities
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Teradata Tools and Utilities
+  SOFTWARE_TITLE: Teradata_Tools_Utilities
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Teradata/Vantage_Editor.download.recipe.yaml
+++ b/Teradata/Vantage_Editor.download.recipe.yaml
@@ -1,0 +1,61 @@
+---
+Identifier: com.github.smithjw.download.Vantage_Editor
+Description: Downloads the latest version of Vantage Editor using a custom processor
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Vantage Editor
+  SOFTWARE_TITLE: Vantage_Editor
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: TeradataProductURLFinder
+    Arguments:
+      app: teradata_vantage_editor
+      architecture: 'aarch64'
+      teradata_username: '%TERADATA_USERNAME%'
+      teradata_password: '%TERADATA_PASSWORD%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      filename: '%SOFTWARE_TITLE%-arm64.pkg'
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+
+  - Processor: TeradataProductURLFinder
+    Arguments:
+      app: teradata_vantage_editor
+      architecture: 'x86'
+      teradata_username: '%TERADATA_USERNAME%'
+      teradata_password: '%TERADATA_PASSWORD%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      filename: '%SOFTWARE_TITLE%-x86_64.pkg'
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.pkg'
+      expected_authority_names:
+        - 'Developer ID Installer: Teradata (Z6K9HW9JJ5)'
+        - 'Developer ID Certification Authority'
+        - 'Apple Root CA'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.pkg'
+      expected_authority_names:
+        - 'Developer ID Installer: Teradata (Z6K9HW9JJ5)'
+        - 'Developer ID Certification Authority'
+        - 'Apple Root CA'

--- a/Teradata/Vantage_Editor.pkg.recipe.yaml
+++ b/Teradata/Vantage_Editor.pkg.recipe.yaml
@@ -1,0 +1,82 @@
+Description: 'Packages Vantage Editor'
+Identifier: com.github.smithjw.pkg.Vantage_Editor
+ParentRecipe: com.github.smithjw.download.Vantage_Editor
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Teradata Vantage Editor
+  SOFTWARE_TITLE: Teradata_Vantage_Editor
+
+Process:
+  - Processor: FlatPkgUnpacker
+    Arguments:
+      flat_pkg_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      skip_payload: false
+      purge_destination: true
+
+  - Processor: FileFinder
+    Arguments:
+      pattern: '%RECIPE_CACHE_DIR%/unpack/*.pkg'
+
+  - Processor: PkgPayloadUnpacker
+    Arguments:
+      pkg_payload_path: '%found_filename%/Payload'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack/payload'
+      purge_destination: true
+
+  - Processor: FileFinder
+    Arguments:
+      pattern: '%RECIPE_CACHE_DIR%/unpack/payload/*.app'
+
+  - Processor: Versioner
+    Arguments:
+      input_plist_path: '%found_filename%/Contents/Info.plist'
+
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-arm64.pkg'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-x86_64.pkg'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/sbin/installer -pkg %SOFTWARE_TITLE%-arm64.pkg -target /
+        else
+          /usr/sbin/installer -pkg %SOFTWARE_TITLE%-x86_64.pkg -target /
+        fi
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: com.teradata.vantage.editor
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'
+        - '%RECIPE_CACHE_DIR%/unpack'

--- a/Teradata/Vantage_Editor.upload.jamf.recipe.yaml
+++ b/Teradata/Vantage_Editor.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Vantage_Editor
+ParentRecipe: com.github.smithjw.pkg.Vantage_Editor
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Vantage Editor
+  SOFTWARE_TITLE: Vantage_Editor
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/UTM/UTM.download.recipe.yaml
+++ b/UTM/UTM.download.recipe.yaml
@@ -1,0 +1,35 @@
+Description: ''
+Identifier: com.github.smithjw.download.UTM
+MinimumVersion: '2.9'
+
+Input:
+  NAME: UTM
+  SOFTWARE_TITLE: '%NAME%'
+  INCLUDE_PRERELEASES: null
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: .*\.dmg$
+      github_repo: utmapp/UTM
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.dmg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/UTM.app'
+      requirement: anchor apple generic and identifier "com.utmapp.UTM" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = WDNLXAD4W8)
+      strict_verification: true

--- a/UTM/UTM.pkg.recipe.yaml
+++ b/UTM/UTM.pkg.recipe.yaml
@@ -1,0 +1,48 @@
+Description: ''
+Identifier: com.github.smithjw.pkg.UTM
+ParentRecipe: com.github.smithjw.download.UTM
+MinimumVersion: '2.9'
+
+Input:
+  NAME: UTM
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgdirs:
+        Applications: '0755'
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+
+  - Processor: Copier
+    Arguments:
+      destination_path: '%RECIPE_CACHE_DIR%/payload/Applications/UTM.app'
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/UTM.app'
+
+  - Processor: PlistReader
+    Arguments:
+      info_path: '%RECIPE_CACHE_DIR%/payload/Applications/UTM.app/Contents/Info.plist'
+      plist_keys:
+        CFBundleIdentifier: bundleid
+        CFBundleName: app_name
+        CFBundleShortVersionString: version
+
+  - Processor: PkgCreator
+    Arguments:
+      force_pkg_build: true
+      pkg_request:
+        chown:
+          - group: wheel
+            path: Applications
+            user: root
+        id: '%bundleid%'
+        options: purge_ds_store
+        pkgname: '%NAME%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/UTM/UTM.upload.jamf.recipe.yaml
+++ b/UTM/UTM.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.UTM
+ParentRecipe: com.github.smithjw.pkg.UTM
+MinimumVersion: '2.9'
+
+Input:
+  NAME: UTM
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Wacom/Wacom_Intuos_Driver.download.recipe.yaml
+++ b/Wacom/Wacom_Intuos_Driver.download.recipe.yaml
@@ -1,0 +1,43 @@
+Description: Downloads the latest version of Wacom Intuos tablet drivers.
+Identifier: com.github.smithjw.download.Wacom_Intuos_Driver
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Wacom Intuos Driver
+  SOFTWARE_TITLE: Wacom_Intuos_Driver
+  DOWNLOAD_URL: https://www.wacom.com/en-us/support/product-support/drivers
+  DOWNLOAD_PATTERN: https://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_+[0-9].+[0-9].+[0-9]*-*[0-9].dmg
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: '%DOWNLOAD_PATTERN%'
+      request_headers:
+        user-agent: 'curl/8.7.1'
+      url: '%DOWNLOAD_URL%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      fetch_filename: true
+      url: '%match%'
+      request_headers:
+        user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Wacom Technology Corp. (EG27766DY7)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%/*.pkg'

--- a/Wacom/Wacom_Intuos_Driver.pkg.recipe.yaml
+++ b/Wacom/Wacom_Intuos_Driver.pkg.recipe.yaml
@@ -1,0 +1,33 @@
+Description: Downloads the latest Wacom Intuos driver disk image and builds a package.
+Identifier: com.github.smithjw.pkg.Wacom_Intuos_Driver
+ParentRecipe: com.github.smithjw.download.Wacom_Intuos_Driver
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Wacom Intuos Driver
+  SOFTWARE_TITLE: Wacom_Intuos_Driver
+
+Process:
+  - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
+    Arguments:
+      archive_path: '%pathname%/*.pkg'
+      file_to_extract: Distribution
+
+  - Processor: com.github.mlbz521.SharedProcessors/XPathParser
+    Arguments:
+      attribute_one: CFBundleShortVersionString
+      return_variable_attribute_one: version
+      xml_file: '%extracted_file%'
+      xpath: .//pkg-ref[@id="com.wacom.TabletInstaller"]/bundle-version/bundle[@id="com.wacom.WacomCenterPrefPane"]
+
+  - Processor: PkgCopier
+    Arguments:
+      source_pkg: '%pathname%/*.pkg'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/extractedfile'
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/Wacom/Wacom_Intuos_Driver.upload.jamf.recipe.yaml
+++ b/Wacom/Wacom_Intuos_Driver.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.Wacom_Intuos_Driver
+ParentRecipe: com.github.smithjw.pkg.Wacom_Intuos_Driver
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Wacom Intuos Driver
+  SOFTWARE_TITLE: Wacom_Intuos_Driver
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Wireshark/Wireshark.download.recipe.yaml
+++ b/Wireshark/Wireshark.download.recipe.yaml
@@ -36,5 +36,7 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%pathname%/Wireshark*.app'
       requirement: anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7Z6EMTD2C6"

--- a/Xcode_CLTools/Xcode_CLTools.download.recipe.yaml
+++ b/Xcode_CLTools/Xcode_CLTools.download.recipe.yaml
@@ -1,0 +1,24 @@
+Comment: |
+  You must manually download the Command Line Tools DMG from the Apple Developer Portal first, then pass it into the recipe with the --pkg option
+Description: Processes the Xcode Command Line Tools DMG manually downloaded from the Apple Developer Portal
+Identifier: com.github.smithjw.download.Xcode_CLTools
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Command Line Tools for Xcode
+  SOFTWARE_TITLE: Xcode_CLTools
+
+Process:
+  - Processor: PackageRequired
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - Software Update
+        - Apple Software Update Certification Authority
+        - Apple Root CA
+      input_path: '%PKG%/*.pkg'

--- a/Xcode_CLTools/Xcode_CLTools.pkg.recipe.yaml
+++ b/Xcode_CLTools/Xcode_CLTools.pkg.recipe.yaml
@@ -1,0 +1,52 @@
+Description: Processes the Xcode Command Line Tools package manually downloaded from the Apple Developer Portal
+Identifier: com.github.smithjw.pkg.Xcode_CLTools
+ParentRecipe: com.github.smithjw.download.Xcode_CLTools
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Command Line Tools for Xcode
+  SOFTWARE_TITLE: Xcode_CLTools
+
+Process:
+  - Processor: FlatPkgUnpacker
+    Arguments:
+      flat_pkg_path: '%PKG%/*.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/flatpkg'
+
+  - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
+    Arguments:
+      archive_path: '%PKG%/*.pkg'
+      file_to_extract: Distribution
+
+  - Processor: com.github.mlbz521.SharedProcessors/XPathParser
+    Arguments:
+      attribute_one: version
+      return_variable_attribute_one: version
+      xml_file: '%extracted_file%'
+      xpath: ./pkg-ref[@id="CLTools_Executables"]
+
+  - Processor: com.github.mlbz521.SharedProcessors/XPathParser
+    Arguments:
+      attribute_one: min
+      return_variable_attribute_one: min_os_version
+      attribute_two: before
+      return_variable_attribute_two: max_os_version
+      xml_file: '%extracted_file%'
+      xpath: .//allowed-os-versions/os-version
+
+  - Processor: com.github.jazzace.processors/TextSearcher
+    Arguments:
+      text_in: '%version%'
+      result_output_var_name: xcode_version
+      re_pattern: '(^\d+\.\d+)'
+
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%PKG%/*.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/extractedfile'

--- a/Xcode_CLTools/Xcode_CLTools.upload.jamf.recipe.yaml
+++ b/Xcode_CLTools/Xcode_CLTools.upload.jamf.recipe.yaml
@@ -1,0 +1,42 @@
+Description: Processes the Xcode Command Line Tools package manually downloaded from the Apple Developer Portal and uploads to Jamf
+Identifier: com.github.smithjw.jamf.upload.Xcode_CLTools
+ParentRecipe: com.github.smithjw.pkg.Xcode_CLTools
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Command Line Tools for Xcode
+  SOFTWARE_TITLE: Xcode_CLTools
+  CATEGORY: Apps
+  PACKAGE_INFO: autopkg
+  PKG_MAX_OS_VERSION: '15.99'
+  PKG_MIN_OS_VERSION: '13.0'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-%xcode_version%-'
+  PKG_TO_KEEP: '2'
+  REMOVE_OLD_PACKAGES: 'true'
+  SMART_GROUP_NAME_PREFIX: '%NAME%'
+  SMART_GROUP_NAME_SUFFIX: ' (%PACKAGE_INFO%)'
+  SMART_GROUP_TEMPLATE: Smart_Group-OS_Requirements-Xcode_CLTools.xml
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfComputerGroupUploader
+    Arguments:
+      computergroup_name: '%SMART_GROUP_NAME_PREFIX% %xcode_version% - macOS %PKG_MIN_OS_VERSION%-%PKG_MAX_OS_VERSION%%SMART_GROUP_NAME_SUFFIX%'
+      computergroup_template: '%SMART_GROUP_TEMPLATE%'
+      replace_group: 'true'
+      sleep: 2
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Xray Exploratory App/Xray_Exploratory_App.download.recipe.yaml
+++ b/Xray Exploratory App/Xray_Exploratory_App.download.recipe.yaml
@@ -23,6 +23,8 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%pathname%/Xray Exploratory App.app'
       requirement: identifier "com.xblend.xea" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6DU9D8Q52R"
 

--- a/Zed/Zed.download.recipe.yaml
+++ b/Zed/Zed.download.recipe.yaml
@@ -45,5 +45,7 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%pathname%/Zed.app'
       requirement: identifier "dev.zed.Zed" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "MQ55VZLNZQ"

--- a/Zeplin/Zeplin.download.recipe.yaml
+++ b/Zeplin/Zeplin.download.recipe.yaml
@@ -1,0 +1,35 @@
+Description: Downloads the latest version of Zeplin.
+Identifier: com.github.smithjw.download.Zeplin
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Zeplin
+  SOFTWARE_TITLE: '%NAME%'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      prefetch_filename: true
+      url: https://zpl.io/download-mac
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      archive_path: '%pathname%'
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      purge_destination: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/unpack/Zeplin.app'
+      requirement: anchor apple generic and identifier "io.zeplin.osx" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8U3Y4X5WDQ")

--- a/Zeplin/Zeplin.pkg.recipe.yaml
+++ b/Zeplin/Zeplin.pkg.recipe.yaml
@@ -1,0 +1,23 @@
+Identifier: com.github.smithjw.pkg.Zeplin
+ParentRecipe: com.github.smithjw.download.Zeplin
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Zeplin
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: Versioner
+    Arguments:
+      input_plist_path: '%RECIPE_CACHE_DIR%/unpack/Zeplin.app/Contents/Info.plist'
+
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/unpack/Zeplin.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/unpack'

--- a/Zeplin/Zeplin.upload.jamf.recipe.yaml
+++ b/Zeplin/Zeplin.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Downloads the latest version of Zeplin, creates a package, then uploads to Jamf
+Identifier: com.github.smithjw.jamf.upload.Zeplin
+ParentRecipe: com.github.smithjw.pkg.Zeplin
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Zeplin
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/Zoom/Zoom_IT.download.recipe.yaml
+++ b/Zoom/Zoom_IT.download.recipe.yaml
@@ -23,6 +23,8 @@ Process:
 
 - Processor: CodeSignatureVerifier
   Arguments:
+    deep_verification: true
+    strict_verification: true
     expected_authority_names:
     - 'Developer ID Installer: Zoom Video Communications, Inc. (BJ4HAAB9B3)'
     - Developer ID Certification Authority

--- a/cmux/cmux.download.recipe.yaml
+++ b/cmux/cmux.download.recipe.yaml
@@ -38,5 +38,7 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%pathname%/cmux.app'
       requirement: identifier "com.cmuxterm.app" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7WLXT3NR37"

--- a/desktoppr/desktoppr.download.recipe.yaml
+++ b/desktoppr/desktoppr.download.recipe.yaml
@@ -1,0 +1,42 @@
+Description: |
+  Downloads the most recent signed release pkg of desktoppr from GitHub.
+
+  In order to get the latest pre-release, set the Input variable INCLUDE_PRERELEASES to a non-empty
+  string (such as 'True'; this is the default). If you just want the latest full release instead,
+  INCLUDE_PRERELEASES must be set to an empty string.
+Identifier: com.github.smithjw.download.desktoppr
+MinimumVersion: '2.9'
+
+Input:
+  NAME: desktoppr
+  SOFTWARE_TITLE: '%NAME%'
+  INCLUDE_PRERELEASES: 'True'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      github_repo: scriptingosx/desktoppr
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.pkg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Armin Briegel (JME5BW3F3R)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/desktoppr/desktoppr.pkg.recipe.yaml
+++ b/desktoppr/desktoppr.pkg.recipe.yaml
@@ -1,0 +1,14 @@
+Description: Downloads the most recent signed release pkg of desktoppr from GitHub and renames the package.
+Identifier: com.github.smithjw.pkg.desktoppr
+ParentRecipe: com.github.smithjw.download.desktoppr
+MinimumVersion: '2.9'
+
+Input:
+  NAME: desktoppr
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%'

--- a/desktoppr/desktoppr.upload.jamf.recipe.yaml
+++ b/desktoppr/desktoppr.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ' '
+Identifier: com.github.smithjw.jamf.upload.desktoppr
+ParentRecipe: com.github.smithjw.pkg.desktoppr
+MinimumVersion: '2.9'
+
+Input:
+  NAME: desktoppr
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Utilities
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/dockutil/dockutil.download.recipe.yaml
+++ b/dockutil/dockutil.download.recipe.yaml
@@ -1,0 +1,37 @@
+Description: ''
+Identifier: com.github.smithjw.download.dockutil
+MinimumVersion: '2.9'
+
+Input:
+  NAME: dockutil
+  SOFTWARE_TITLE: '%NAME%'
+  INCLUDE_PRERELEASES: 'True'
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      github_repo: kcrawford/dockutil
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.pkg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Kyle Crawford (Z5J8CJBUWC)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/dockutil/dockutil.pkg.recipe.yaml
+++ b/dockutil/dockutil.pkg.recipe.yaml
@@ -1,0 +1,14 @@
+Description: ''
+Identifier: com.github.smithjw.pkg.dockutil
+ParentRecipe: com.github.smithjw.download.dockutil
+MinimumVersion: '2.9'
+
+Input:
+  NAME: dockutil
+  SOFTWARE_TITLE: '%NAME%'
+
+Process:
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%'

--- a/dockutil/dockutil.upload.jamf.recipe.yaml
+++ b/dockutil/dockutil.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.dockutil
+ParentRecipe: com.github.smithjw.pkg.dockutil
+MinimumVersion: '2.9'
+
+Input:
+  NAME: dockutil
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Utilities
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/draw_io/draw_io.download.recipe.yaml
+++ b/draw_io/draw_io.download.recipe.yaml
@@ -1,0 +1,43 @@
+Description: |
+  Downloads draw.io (drawio-desktop) from GitHub Releases and produces a verified
+  artefact for downstream packaging. Pulls the universal `.dmg` asset.
+
+  Run as part of the full download → pkg → upload chain. The `URLDownloaderPython`
+  processor caches by ETag/Last-Modified/Content-Length and the
+  `StopProcessingIf download_changed == False` predicate short-circuits the chain
+  on no-op re-runs. Pointing the upload recipe at a pre-built pkg would defeat
+  this cache and re-upload on every CI run.
+Identifier: com.github.smithjw.download.draw_io
+MinimumVersion: '2.9'
+
+Input:
+  NAME: draw.io
+  SOFTWARE_TITLE: draw_io
+  INCLUDE_PRERELEASES: null
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: 'draw\.io-universal-[\d.]+\.dmg'
+      github_repo: jgraph/drawio-desktop
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.dmg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/draw.io.app'
+      requirement: identifier "com.jgraph.drawio.desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "UZEUFB4N53"
+      strict_verification: true

--- a/draw_io/draw_io.pkg.recipe.yaml
+++ b/draw_io/draw_io.pkg.recipe.yaml
@@ -1,0 +1,17 @@
+Description: |
+  Packaging step for draw.io. Wraps the downloaded `draw.io.app` into an installer
+  pkg. Must run after the download recipe so `URLDownloaderPython` caching can
+  short-circuit unchanged builds.
+Identifier: com.github.smithjw.pkg.draw_io
+ParentRecipe: com.github.smithjw.download.draw_io
+MinimumVersion: '2.9'
+
+Input:
+  NAME: draw.io
+  SOFTWARE_TITLE: draw_io
+
+Process:
+  - Processor: AppPkgCreator
+    Arguments:
+      app_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%.dmg/draw.io.app'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/draw_io/draw_io.upload.jamf.recipe.yaml
+++ b/draw_io/draw_io.upload.jamf.recipe.yaml
@@ -1,0 +1,35 @@
+Description: |
+  Final step for draw.io: uploads the pkg to Jamf Pro and rotates old packages
+  (keeps the most recent 2). Downstream override repos can override this recipe to
+  attach policies / scopes specific to their environment. Run as part of the full
+  download → pkg → upload chain so `URLDownloaderPython` caching can short-circuit
+  unchanged builds.
+Identifier: com.github.smithjw.jamf.upload.draw_io
+ParentRecipe: com.github.smithjw.pkg.draw_io
+MinimumVersion: '2.9'
+
+Input:
+  NAME: draw.io
+  SOFTWARE_TITLE: draw_io
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/iTerm/iTerm.download.recipe.yaml
+++ b/iTerm/iTerm.download.recipe.yaml
@@ -1,0 +1,37 @@
+Description: Downloads the latest version of iTerm
+Identifier: com.github.smithjw.download.iTerm
+MinimumVersion: '2.9'
+
+Input:
+  NAME: iTerm
+  SOFTWARE_TITLE: '%NAME%'
+  DOWNLOAD_URL: https://iterm2.com/downloads/stable/latest
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      request_headers:
+        user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%.zip'
+      url: '%DOWNLOAD_URL%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: Unarchiver
+    Arguments:
+      destination_path: '%RECIPE_CACHE_DIR%/unpack'
+      purge_destination: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/unpack/iTerm.app'
+      requirement: anchor apple generic and identifier "com.googlecode.iterm2" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = H7V7XYVQ7D)
+      strict_verification: true

--- a/iTerm/iTerm.pkg.recipe.yaml
+++ b/iTerm/iTerm.pkg.recipe.yaml
@@ -1,0 +1,49 @@
+Description: Downloads the latest version of iTerm and creates a package.
+Identifier: com.github.smithjw.pkg.iTerm
+ParentRecipe: com.github.smithjw.download.iTerm
+MinimumVersion: '2.9'
+
+Input:
+  NAME: iTerm
+  SOFTWARE_TITLE: iTerm
+
+Process:
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgdirs:
+        Applications: '0755'
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+
+  - Processor: FileMover
+    Arguments:
+      source: '%RECIPE_CACHE_DIR%/unpack/iTerm.app'
+      target: '%RECIPE_CACHE_DIR%/payload/Applications/iTerm.app'
+
+  - Processor: PlistReader
+    Arguments:
+      info_path: '%RECIPE_CACHE_DIR%/payload/Applications/iTerm.app/Contents/Info.plist'
+      plist_keys:
+        CFBundleIdentifier: bundleid
+        CFBundleName: app_name
+        CFBundleShortVersionString: version
+
+  - Processor: PkgCreator
+    Arguments:
+      force_pkg_build: true
+      pkg_request:
+        chown:
+          - group: wheel
+            path: Applications
+            user: root
+        id: '%bundleid%'
+        options: purge_ds_store
+        pkgname: '%NAME%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/unpack'
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/iTerm/iTerm.upload.jamf.recipe.yaml
+++ b/iTerm/iTerm.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Downloads the latest version of iTerm, creates a package, then uploads to Jamf
+Identifier: com.github.smithjw.jamf.upload.iTerm
+ParentRecipe: com.github.smithjw.pkg.iTerm
+MinimumVersion: '2.9'
+
+Input:
+  NAME: iTerm
+  SOFTWARE_TITLE: '%NAME%'
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/iTerm2/iTerm2.download.recipe.yaml
+++ b/iTerm2/iTerm2.download.recipe.yaml
@@ -31,6 +31,8 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%RECIPE_CACHE_DIR%/unpack/iTerm.app'
       requirement: 'anchor apple generic and identifier "com.googlecode.iterm2" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = H7V7XYVQ7D)'
 

--- a/kitty/kitty.download.recipe.yaml
+++ b/kitty/kitty.download.recipe.yaml
@@ -38,5 +38,7 @@ Process:
 
   - Processor: CodeSignatureVerifier
     Arguments:
+      deep_verification: true
+      strict_verification: true
       input_path: '%pathname%/kitty.app'
       requirement: identifier "net.kovidgoyal.kitty" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "NTY7FVCEKP"

--- a/osquery/osquery.download.recipe.yaml
+++ b/osquery/osquery.download.recipe.yaml
@@ -1,0 +1,39 @@
+Description: ''
+Identifier: com.github.smithjw.download.osquery
+MinimumVersion: '2.9'
+
+Input:
+  NAME: osquery
+  SOFTWARE_TITLE: osquery
+  INCLUDE_PRERELEASES: null
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: '.*\.pkg'
+      github_repo: osquery/osquery
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      fetch_filename: true
+      # filename: '%SOFTWARE_TITLE%.pkg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: OSQUERY A Series of LF Projects, LLC (3522FA9PXF)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/osquery/osquery.pkg.recipe.yaml
+++ b/osquery/osquery.pkg.recipe.yaml
@@ -1,0 +1,14 @@
+Description: ''
+Identifier: com.github.smithjw.pkg.osquery
+ParentRecipe: com.github.smithjw.download.osquery
+MinimumVersion: '2.9'
+
+Input:
+  NAME: osquery
+  SOFTWARE_TITLE: osquery
+
+Process:
+  - Processor: PkgCopier
+    Arguments:
+      source_pkg: '%pathname%'
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'

--- a/osquery/osquery.upload.jamf.recipe.yaml
+++ b/osquery/osquery.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.osquery
+ParentRecipe: com.github.smithjw.pkg.osquery
+MinimumVersion: '2.9'
+
+Input:
+  NAME: osquery
+  SOFTWARE_TITLE: osquery
+  CATEGORY: Utilities
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/pgAdmin4/pgAdmin4.download.recipe.yaml
+++ b/pgAdmin4/pgAdmin4.download.recipe.yaml
@@ -1,0 +1,66 @@
+Description: Downloads the current version of pgAdmin 4.
+Identifier: com.github.smithjw.download.pgAdmin4
+MinimumVersion: '2.9'
+
+Input:
+  NAME: pgAdmin 4
+  SOFTWARE_TITLE: pgAdmin4
+  DOWNLOAD_URL: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLTextSearcher
+    Arguments:
+      url: https://www.pgadmin.org/download/pgadmin-4-macos/
+      re_pattern: 'href="(https://www\.postgresql\.org/ftp/pgadmin/pgadmin4/v(?P<latest_version>([0-9\.]+))/macos/)"'
+      result_output_var_name: postgresql_url
+
+  - Processor: URLTextSearcher
+    Arguments:
+      url: '%postgresql_url%'
+      re_pattern: 'href="(https://ftp\.postgresql\.org/pub/pgadmin/pgadmin4/v%latest_version%/macos/pgadmin4-%latest_version%-arm64\.dmg)"'
+      result_output_var_name: download_url_arm64
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      filename: '%SOFTWARE_TITLE%-arm64.dmg'
+      url: '%download_url_arm64%'
+
+  - Processor: URLTextSearcher
+    Arguments:
+      url: '%postgresql_url%'
+      re_pattern: 'href="(https://ftp\.postgresql\.org/pub/pgadmin/pgadmin4/v%latest_version%/macos/pgadmin4-%latest_version%-x64\.dmg)"'
+      result_output_var_name: download_url_x86_64
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      filename: '%SOFTWARE_TITLE%-x86_64.dmg'
+      url: '%download_url_x86_64%'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/pgAdmin 4.app'
+      requirement: |
+        identifier "org.pgadmin.pgadmin4" and anchor apple generic and
+        certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and
+        certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and
+        certificate leaf[subject.OU] = TCHGL2R7C5
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg/pgAdmin 4.app'
+      requirement: |
+        identifier "org.pgadmin.pgadmin4" and anchor apple generic and
+        certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and
+        certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and
+        certificate leaf[subject.OU] = TCHGL2R7C5

--- a/pgAdmin4/pgAdmin4.pkg.recipe.yaml
+++ b/pgAdmin4/pgAdmin4.pkg.recipe.yaml
@@ -1,0 +1,67 @@
+Description: Package the current  version of pgAdmin 4.
+Identifier: com.github.smithjw.pkg.pgAdmin4
+ParentRecipe: com.github.smithjw.download.pgAdmin4
+MinimumVersion: '2.9'
+
+Input:
+  NAME: pgAdmin 4
+  SOFTWARE_TITLE: pgAdmin4
+
+Process:
+  - Processor: PlistReader
+    Arguments:
+      info_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/pgAdmin 4.app/Contents/Info.plist'
+      plist_keys:
+        CFBundleIdentifier: bundleid
+        CFBundleName: app_name
+        CFBundleShortVersionString: version
+
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-arm64.dmg'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-x86_64.dmg'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/bin/hdiutil attach "%SOFTWARE_TITLE%-arm64.dmg" -mountpoint "/Volumes/%SOFTWARE_TITLE%" -nobrowse
+        else
+          /usr/bin/hdiutil attach "%SOFTWARE_TITLE%-x86_64.dmg" -mountpoint "/Volumes/%SOFTWARE_TITLE%" -nobrowse
+        fi
+
+        /bin/cp -R "/Volumes/%SOFTWARE_TITLE%/pgAdmin 4.app" "/Applications/pgAdmin 4.app"
+        /usr/bin/hdiutil detach "/Volumes/%SOFTWARE_TITLE%"
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: '%bundleid%'
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/pgAdmin4/pgAdmin4.upload.jamf.recipe.yaml
+++ b/pgAdmin4/pgAdmin4.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: ''
+Identifier: com.github.smithjw.jamf.upload.pgAdmin4
+ParentRecipe: com.github.smithjw.pkg.pgAdmin4
+MinimumVersion: '2.9'
+
+Input:
+  NAME: pgAdmin 4
+  SOFTWARE_TITLE: pgAdmin4
+  CATEGORY: Apps
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+  REMOVE_OLD_PACKAGES: 'true'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/swiftDialog/swiftDialog.download.recipe.yaml
+++ b/swiftDialog/swiftDialog.download.recipe.yaml
@@ -1,0 +1,53 @@
+Description: |
+  Downloads swiftDialog from GitHub Releases and produces a verified artefact for
+  downstream packaging.
+
+  Run as part of the full download → pkg → upload chain. The `URLDownloaderPython`
+  processor caches by ETag/Last-Modified/Content-Length and the
+  `StopProcessingIf download_changed == False` predicate short-circuits the chain
+  on no-op re-runs. Pointing the upload recipe at a pre-built pkg would defeat
+  this cache and re-upload on every CI run.
+
+  Source: GitHub Releases at `swiftDialog/swiftDialog`. Asset is a signed `.pkg`
+  produced by CSIRO (the project's origin institution); we keep the CSIRO authority
+  chain in `expected_authority_names`. `INCLUDE_PRERELEASES` defaults to null
+  (release-only) since swiftDialog often sits on critical notification paths where
+  stability matters more than newness; set to any non-empty string to include
+  pre-releases.
+Identifier: com.github.smithjw.download.swiftDialog
+MinimumVersion: '2.9'
+
+Input:
+  NAME: swiftDialog
+  SOFTWARE_TITLE: swiftDialog
+  INCLUDE_PRERELEASES: null
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: GitHubReleasesInfoProvider
+    Arguments:
+      asset_regex: 'dialog-[\d.]+-[\d]+\.pkg'
+      github_repo: swiftDialog/swiftDialog
+      include_prereleases: '%INCLUDE_PRERELEASES%'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-%version%.pkg'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      strict_verification: true
+      expected_authority_names:
+        - 'Developer ID Installer: Commonwealth Scientific and Industrial Research Organisation (PWA5E9TQ59)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%pathname%'

--- a/swiftDialog/swiftDialog.pkg.recipe.yaml
+++ b/swiftDialog/swiftDialog.pkg.recipe.yaml
@@ -1,0 +1,18 @@
+Description: |
+  Packaging step for swiftDialog. The upstream artefact is already a signed `.pkg`,
+  so we only rename it to `swiftDialog-<version>.pkg` for downstream discoverability.
+  Must run after the download recipe so `URLDownloaderPython` caching can
+  short-circuit unchanged builds.
+Identifier: com.github.smithjw.pkg.swiftDialog
+ParentRecipe: com.github.smithjw.download.swiftDialog
+MinimumVersion: '2.9'
+
+Input:
+  NAME: swiftDialog
+  SOFTWARE_TITLE: swiftDialog
+
+Process:
+  - Processor: PkgCopier
+    Arguments:
+      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
+      source_pkg: '%pathname%'

--- a/swiftDialog/swiftDialog.upload.jamf.recipe.yaml
+++ b/swiftDialog/swiftDialog.upload.jamf.recipe.yaml
@@ -1,0 +1,35 @@
+Description: |
+  Final step for swiftDialog: uploads the renamed pkg to Jamf Pro and rotates old
+  packages (keeps the most recent 2). Downstream override repos can override this
+  recipe to attach policies / scopes specific to their environment. Run as part of
+  the full download → pkg → upload chain so `URLDownloaderPython` caching can
+  short-circuit unchanged builds.
+Identifier: com.github.smithjw.jamf.upload.swiftDialog
+ParentRecipe: com.github.smithjw.pkg.swiftDialog
+MinimumVersion: '2.9'
+
+Input:
+  NAME: swiftDialog
+  SOFTWARE_TITLE: swiftDialog
+  CATEGORY: Utilities
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '2'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'

--- a/wizcli/WizVersionExtractor.py
+++ b/wizcli/WizVersionExtractor.py
@@ -1,0 +1,66 @@
+#!/usr/local/autopkg/python
+"""
+WizVersionExtractor - Extracts version from Wiz CLI binary
+"""
+
+import subprocess
+import re
+from autopkglib import Processor, ProcessorError
+
+__all__ = ["WizVersionExtractor"]
+
+class WizVersionExtractor(Processor):
+    """Extracts version from Wiz CLI binary by executing it."""
+
+    description = __doc__
+
+    input_variables = {
+        "input_path": {
+            "required": True,
+            "description": "Path to the Wiz CLI binary to extract version from.",
+        },
+    }
+
+    output_variables = {
+        "version": {
+            "description": "Version extracted from the Wiz CLI binary.",
+        },
+    }
+
+    def main(self):
+        binary_path = self.env["input_path"]
+
+        try:
+            # Make binary executable
+            subprocess.run(['/bin/chmod', '+x', binary_path], check=True, capture_output=True)
+
+            # Execute wizcli version
+            result = subprocess.run(
+                [binary_path, 'version'],
+                capture_output=True,
+                text=True,
+                check=True
+            )
+
+            # Wiz CLI outputs version to stderr, not stdout
+            output = result.stdout + result.stderr
+
+            # Extract version from output
+            # Expected format: "Wiz CLI vX.Y.Z" or just "vX.Y.Z"
+            version_match = re.search(r'v?([0-9]+\.[0-9]+\.[0-9]+)', output)
+
+            if version_match:
+                version = version_match.group(1)
+                self.env["version"] = version
+                self.output(f"Extracted version: {version}")
+            else:
+                raise ProcessorError(f"Could not extract version from output. stdout: {result.stdout}, stderr: {result.stderr}")
+
+        except subprocess.CalledProcessError as e:
+            raise ProcessorError(f"Failed to execute binary: {e.stderr}")
+        except Exception as e:
+            raise ProcessorError(f"Error extracting version: {str(e)}")
+
+if __name__ == "__main__":
+    PROCESSOR = WizVersionExtractor()
+    PROCESSOR.execute_shell()

--- a/wizcli/wizcli.download.recipe.yaml
+++ b/wizcli/wizcli.download.recipe.yaml
@@ -1,0 +1,51 @@
+Description: Downloads the latest versions of the Wiz CLI (Apple Silicon and
+  Intel) from the official source and verifies their code signatures.
+Identifier: com.github.smithjw.download.wizcli
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Wiz CLI
+  SOFTWARE_TITLE: wizcli
+  DOWNLOAD_MISSING_FILE: null
+  BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED: 'False'
+
+Process:
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      url: https://downloads.wiz.io/v1/wizcli/latest/wizcli-darwin-arm64
+      filename: '%SOFTWARE_TITLE%-arm64'
+
+  - Processor: URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      url: https://downloads.wiz.io/v1/wizcli/latest/wizcli-darwin-amd64
+      filename: '%SOFTWARE_TITLE%-x86_64'
+
+  - Processor: EndOfCheckPhase
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: 'download_changed == False AND %BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED% == False'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64'
+      requirement: >-
+        identifier "a.out" and anchor apple generic and certificate
+        1[field.1.2.840.113635.100.6.2.6] and certificate
+        leaf[field.1.2.840.113635.100.6.1.13] and certificate leaf[subject.OU] =
+        "7FAWH6LYL8"
+      strict_verification: true
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      deep_verification: true
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64'
+      requirement: >-
+        identifier "wizcli-darwin-amd64" and anchor apple generic and
+        certificate 1[field.1.2.840.113635.100.6.2.6] and certificate
+        leaf[field.1.2.840.113635.100.6.1.13] and certificate leaf[subject.OU] =
+        "7FAWH6LYL8"
+      strict_verification: true

--- a/wizcli/wizcli.pkg.recipe.yaml
+++ b/wizcli/wizcli.pkg.recipe.yaml
@@ -1,0 +1,62 @@
+Description: Packages the latest Wiz CLI as a universal installer.
+Identifier: com.github.smithjw.pkg.wizcli
+ParentRecipe: com.github.smithjw.download.wizcli
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Wiz CLI
+  SOFTWARE_TITLE: wizcli
+
+Process:
+  - Processor: WizVersionExtractor
+    Arguments:
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64'
+
+  - Processor: PkgRootCreator
+    Arguments:
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0755'
+        scripts: '0755'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/wizcli-arm64'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/wizcli-x86_64'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /bin/mv wizcli-arm64 /usr/local/bin/wizcli
+        else
+          /bin/mv wizcli-x86_64 /usr/local/bin/wizcli
+        fi
+        /bin/chmod 0755 /usr/local/bin/wizcli
+        /usr/sbin/chown root:wheel /usr/local/bin/wizcli
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: io.wiz.wizcli
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
+
+  - Processor: com.github.smithjw.processors/FriendlyPathDeleter
+    Arguments:
+      fail_deleter_silently: true
+      path_list:
+        - '%RECIPE_CACHE_DIR%/payload'

--- a/wizcli/wizcli.upload.jamf.recipe.yaml
+++ b/wizcli/wizcli.upload.jamf.recipe.yaml
@@ -1,0 +1,30 @@
+Description: Downloads, packages, and uploads Wiz CLI to Jamf Pro (package only, no policy).
+Identifier: com.github.smithjw.jamf.upload.wizcli
+ParentRecipe: com.github.smithjw.pkg.wizcli
+MinimumVersion: '2.9'
+
+Input:
+  NAME: Wiz CLI
+  SOFTWARE_TITLE: wizcli
+  CATEGORY: Apps
+  REMOVE_OLD_PACKAGES: 'true'
+  PACKAGE_INFO: autopkg
+  PKG_TO_KEEP: '4'
+  PKG_NAME_MATCH: '%SOFTWARE_TITLE%-'
+
+Process:
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageUploader
+    Arguments:
+      pkg_category: '%CATEGORY%'
+      pkg_info: '%PACKAGE_INFO%'
+
+  - Processor: com.github.grahampugh.recipes.postprocessors/LastRecipeRunResult
+
+  - Processor: StopProcessingIf
+    Arguments:
+      predicate: '%REMOVE_OLD_PACKAGES% == false'
+
+  - Processor: com.github.grahampugh.jamf-upload.processors/JamfPackageCleaner
+    Arguments:
+      pkg_name_match: '%PKG_NAME_MATCH%'
+      versions_to_keep: '%PKG_TO_KEEP%'


### PR DESCRIPTION
- Introduced `draw_io.download.recipe.yaml` to download the latest version from GitHub Releases.
- Created `draw_io.pkg.recipe.yaml` to package the downloaded application into a `.pkg`.
- Added `draw_io.upload.jamf.recipe.yaml` for uploading the package to Jamf Pro, including old package rotation.

feat(iTerm): ✨ Implement download, packaging, and upload recipes for iTerm

- Added `iTerm.download.recipe.yaml` to fetch the latest version from the official site.
- Created `iTerm.pkg.recipe.yaml` to package the application for distribution.
- Introduced `iTerm.upload.jamf.recipe.yaml` for uploading the package to Jamf Pro.

feat(iTerm2): ✨ Enhance iTerm2 download recipe with strict verification

- Updated `iTerm2.download.recipe.yaml` to include `deep_verification` and `strict_verification` in the `CodeSignatureVerifier`.

feat(kitty): ✨ Improve kitty download recipe with strict verification

- Enhanced `kitty.download.recipe.yaml` to enforce `deep_verification` and `strict_verification` for code signing.

feat(osquery): ✨ Add download, packaging, and upload recipes for osquery

- Introduced `osquery.download.recipe.yaml` to download the latest version from GitHub.
- Created `osquery.pkg.recipe.yaml` for packaging the downloaded application.
- Added `osquery.upload.jamf.recipe.yaml` for uploading the package to Jamf Pro.

feat(pgAdmin4): ✨ Implement download, packaging, and upload recipes for pgAdmin 4

- Added `pgAdmin4.download.recipe.yaml` to fetch the latest version from the official site.
- Created `pgAdmin4.pkg.recipe.yaml` to package the application for distribution.
- Introduced `pgAdmin4.upload.jamf.recipe.yaml` for uploading the package to Jamf Pro.

feat(swiftDialog): ✨ Add download, packaging, and upload recipes for swiftDialog

- Introduced `swiftDialog.download.recipe.yaml` to download the latest version from GitHub Releases.
- Created `swiftDialog.pkg.recipe.yaml` to package the downloaded application.
- Added `swiftDialog.upload.jamf.recipe.yaml` for uploading the package to Jamf Pro.

feat(wizcli): ✨ Add download, packaging, and upload recipes for Wiz CLI

- Introduced `wizcli.download.recipe.yaml` to download the latest versions for both architectures.
- Created `wizcli.pkg.recipe.yaml` to package the downloaded binaries into a universal installer.
- Added `wizcli.upload.jamf.recipe.yaml` for uploading the package to Jamf Pro.